### PR TITLE
Change prettier configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+dist
+build
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,10 +1,12 @@
 {
-  "semi": true,
-  "trailingComma": "es5",
-  "singleQuote": true,
+  "$schema": "https://json.schemastore.org/prettierrc",
   "printWidth": 100,
   "tabWidth": 2,
   "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
   "bracketSpacing": true,
-  "arrowParens": "avoid"
+  "arrowParens": "always",
+  "endOfLine": "lf"
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "test:run": "vitest run",
         "lint": "eslint src --ext .ts",
         "lint:fix": "eslint src --ext .ts --fix",
-        "format": "prettier --write src/**/*.ts",
+        "format": "prettier --write \"**/*.{cjs,cts,js,json,mjs,mts,ts}\"",
         "prepublishOnly": "npm run clean && npm run build",
         "cli": "node dist/cli.js",
         "eval": "node dist/cli.js eval",


### PR DESCRIPTION
This pull request changes the prettier configuration:
- consistently use 2 spaces for indentation like commonly done
- apply the formatter to config files too

Once https://github.com/openai/openai-guardrails-js/pull/7 is merged, I will run `npm run format` and commit the changes to this PR.