### PR TITLE
Fix: Correctly use context model for moderation

### DIFF
--- a/src/__tests__/unit/checks/moderation-secret-keys.test.ts
+++ b/src/__tests__/unit/checks/moderation-secret-keys.test.ts
@@ -102,6 +102,7 @@ describe('moderation guardrail', () => {
     expect(contextCreateMock).toHaveBeenCalledWith({
       model: 'omni-moderation-latest',
       input: 'test text',
+      safety_identifier: 'openai-guardrails-js',
     });
     expect(result.tripwireTriggered).toBe(false);
   });

--- a/src/checks/moderation.ts
+++ b/src/checks/moderation.ts
@@ -156,7 +156,6 @@ export const moderationCheck: CheckFn<ModerationContext, string, ModerationConfi
       try {
         resp = await callModerationAPI(client, data);
       } catch (error) {
-        
         // Moderation endpoint doesn't exist on this provider (e.g., third-party)
         // Fall back to the OpenAI client
         if (isNotFoundError(error)) {


### PR DESCRIPTION
Fixes this reported [BUG](https://github.com/openai/openai-guardrails-js/issues/21): 
- `apiKey` passed in via client initialization is not properly passed to `moderation` check

The fix:
- Default to using the `guardrail_llm`, if the moderation endpoint does not exist with that client, fall back to creating a compatible OpenAI client via `env variable`
- Documentation already mentions how an `OpenAI API key` is required for the Moderation check
- Added tests

Future PR to allow configuring an `api_key` specific to the moderation check via the config file (will only be needed for users who are using non-openai models as their base client).