### PR TITLE
Fix custom and off topic to use llm_base

### DIFF
--- a/src/checks/user-defined-llm.ts
+++ b/src/checks/user-defined-llm.ts
@@ -7,22 +7,17 @@
  */
 
 import { z } from 'zod';
-import { CheckFn, GuardrailResult } from '../types';
-import { defaultSpecRegistry } from '../registry';
-import { SAFETY_IDENTIFIER, supportsSafetyIdentifier } from '../utils/safety-identifier';
+import { CheckFn, GuardrailLLMContext } from '../types';
+import { LLMConfig, LLMOutput, createLLMCheckFn } from './llm-base';
 
 /**
  * Configuration schema for user-defined LLM moderation checks.
  *
  * Extends the base LLMConfig with a required field for custom prompt details.
  */
-export const UserDefinedConfig = z.object({
-  /** The LLM model to use for content checking */
-  model: z.string(),
-  /** Minimum confidence score (0.0 to 1.0) required to trigger the guardrail. Defaults to 0.7. */
-  confidence_threshold: z.number().min(0.0).max(1.0).default(0.7),
+export const UserDefinedConfig = LLMConfig.omit({ system_prompt_details: true }).extend({
   /** Free-form instructions describing content moderation requirements */
-  system_prompt_details: z.string(),
+  system_prompt_details: z.string().describe('Free-form instructions describing content moderation requirements'),
 });
 
 export type UserDefinedConfig = z.infer<typeof UserDefinedConfig>;
@@ -30,21 +25,12 @@ export type UserDefinedConfig = z.infer<typeof UserDefinedConfig>;
 /**
  * Context requirements for the user-defined LLM guardrail.
  */
-export const UserDefinedContext = z.object({
-  /** OpenAI client for LLM operations */
-  guardrailLlm: z.any(),
-});
-
-export type UserDefinedContext = z.infer<typeof UserDefinedContext>;
+export type UserDefinedContext = GuardrailLLMContext;
 
 /**
  * Output schema for user-defined LLM analysis.
  */
-export const UserDefinedOutput = z.object({
-  /** Whether the content was flagged according to the custom criteria */
-  flagged: z.boolean(),
-  /** Confidence score (0.0 to 1.0) that the input violates the custom criteria */
-  confidence: z.number().min(0.0).max(1.0),
+export const UserDefinedOutput = LLMOutput.extend({
   /** Optional reason for the flagging decision */
   reason: z.string().optional(),
 });
@@ -58,168 +44,19 @@ const SYSTEM_PROMPT = `# Instructions
 
 {system_prompt_details}
 
-Flag any content that matches the criteria defined above.
-
-Respond with a JSON object containing:
-- "flagged": boolean indicating if content violates the criteria
-- "confidence": number between 0.0 and 1.0 indicating confidence in the assessment`;
+Flag any content that matches the criteria defined above.`;
 
 /**
  * User-defined LLM guardrail.
  *
  * Runs a user-defined guardrail based on a custom system prompt.
  * Allows for flexible content moderation based on specific requirements.
- *
- * @param ctx Guardrail context containing the LLM client.
- * @param data Text to analyze according to custom criteria.
- * @param config Configuration with custom system prompt details.
- * @returns GuardrailResult containing analysis with flagged status
- *         and confidence score.
  */
-export const userDefinedLLMCheck: CheckFn<UserDefinedContext, string, UserDefinedConfig> = async (
-  ctx,
-  data,
-  config
-): Promise<GuardrailResult> => {
-  try {
-    // Render the system prompt with custom details
-    const renderedSystemPrompt = SYSTEM_PROMPT.replace(
-      '{system_prompt_details}',
-      config.system_prompt_details
-    );
-
-    // Use the OpenAI API to analyze the text
-    // Try with JSON response format first, fall back to text if not supported
-    let response;
-    try {
-      // Build API call parameters
-      const params: Record<string, unknown> = {
-        messages: [
-          { role: 'system', content: renderedSystemPrompt },
-          { role: 'user', content: data },
-        ],
-        model: config.model,
-        temperature: 0.0,
-        response_format: { type: 'json_object' },
-      };
-      
-      // Only include safety_identifier for official OpenAI API (not Azure or local providers)
-      if (supportsSafetyIdentifier(ctx.guardrailLlm)) {
-        // @ts-ignore - safety_identifier is not defined in OpenAI types yet
-        params.safety_identifier = SAFETY_IDENTIFIER;
-      }
-      
-      response = await ctx.guardrailLlm.chat.completions.create(params);
-    } catch (error: unknown) {
-      // If JSON response format is not supported, try without it
-      if (error && typeof error === 'object' && 'error' in error && 
-          (error as { error?: { param?: string } }).error?.param === 'response_format') {
-        // Build fallback parameters without response_format
-        const fallbackParams: Record<string, unknown> = {
-          messages: [
-            { role: 'system', content: renderedSystemPrompt },
-            { role: 'user', content: data },
-          ],
-          model: config.model,
-          temperature: 0.0,
-        };
-        
-        // Only include safety_identifier for official OpenAI API (not Azure or local providers)
-        if (supportsSafetyIdentifier(ctx.guardrailLlm)) {
-          // @ts-ignore - safety_identifier is not defined in OpenAI types yet
-          fallbackParams.safety_identifier = SAFETY_IDENTIFIER;
-        }
-        
-        response = await ctx.guardrailLlm.chat.completions.create(fallbackParams);
-      } else {
-        // Return error information instead of re-throwing
-        return {
-          tripwireTriggered: false,
-          executionFailed: true,
-          originalException: error instanceof Error ? error : new Error(String(error)),
-          info: {
-            checked_text: data,
-            error_message: String(error),
-            flagged: false,
-            confidence: 0.0,
-          },
-        };
-      }
-    }
-
-    const content = response.choices[0]?.message?.content;
-    if (!content) {
-      return {
-        tripwireTriggered: false,
-        executionFailed: true,
-        originalException: new Error('No response content from LLM'),
-        info: {
-          checked_text: data,
-          error_message: 'No response content from LLM',
-          flagged: false,
-          confidence: 0.0,
-        },
-      };
-    }
-
-    // Parse the response - try JSON first, fall back to text parsing
-    let analysis: UserDefinedOutput;
-    try {
-      analysis = JSON.parse(content);
-    } catch {
-      // If JSON parsing fails, try to extract information from text response
-      // Look for patterns like "flagged: true/false" and "confidence: 0.8"
-      const flaggedMatch = content.match(/flagged:\s*(true|false)/i);
-      const confidenceMatch = content.match(/confidence:\s*([0-9.]+)/i);
-      const reasonMatch = content.match(/reason:\s*"([^"]+)"/i);
-
-      analysis = {
-        flagged: flaggedMatch ? flaggedMatch[1].toLowerCase() === 'true' : false,
-        confidence: confidenceMatch ? parseFloat(confidenceMatch[1]) : 0.0,
-        reason: reasonMatch ? reasonMatch[1] : 'Could not parse response format',
-      };
-    }
-
-    // Determine if tripwire should be triggered
-    const isTrigger = analysis.flagged && analysis.confidence >= config.confidence_threshold;
-
-    return {
-      tripwireTriggered: isTrigger,
-      info: {
-        checked_text: data, // Custom check doesn't modify the text
-        guardrail_name: 'Custom Prompt Check',
-        ...analysis,
-        threshold: config.confidence_threshold,
-        custom_prompt: config.system_prompt_details,
-      },
-    };
-  } catch (error) {
-    // Log unexpected errors and return safe default
-    console.error('Unexpected error in user-defined LLM check:', error);
-    return {
-      tripwireTriggered: false,
-      executionFailed: true,
-      originalException: error instanceof Error ? error : new Error(String(error)),
-      info: {
-        checked_text: data, // Return original text on error
-        guardrail_name: 'Custom Prompt Check',
-        flagged: false,
-        confidence: 0.0,
-        threshold: config.confidence_threshold,
-        custom_prompt: config.system_prompt_details,
-        error: String(error),
-      },
-    };
-  }
-};
-
-// Auto-register this guardrail with the default registry
-defaultSpecRegistry.register(
-  'Custom Prompt Check',
-  userDefinedLLMCheck,
-  'User-defined LLM guardrail for custom content moderation',
-  'text/plain',
-  UserDefinedConfig as z.ZodType<UserDefinedConfig>,
-  UserDefinedContext,
-  { engine: 'llm' }
-);
+export const userDefinedLLM: CheckFn<UserDefinedContext, string, UserDefinedConfig> =
+  createLLMCheckFn(
+    'Custom Prompt Check',
+    'User-defined LLM guardrail for custom content moderation',
+    SYSTEM_PROMPT,
+    UserDefinedOutput,
+    UserDefinedConfig as unknown as typeof LLMConfig
+  ) as CheckFn<UserDefinedContext, string, UserDefinedConfig>;


### PR DESCRIPTION
Fixes reported [[BUG #29  ]](https://github.com/openai/openai-guardrails-js/issues/29)
- `topical-alignment` check hard codes `temperature=0` which is not valid for `gpt-5` series models and causes an error

The fix:
- All LLM based checks should be using `llm-base` which properly handles the `temperature` param
- Additionally noticed `user-defined-llms` was not properly using `llm-base`, fixed that
- Updated tests for both guardrails