### PR TITLE
Return Guardrail token usage

### DIFF
--- a/docs/agents_sdk_integration.md
+++ b/docs/agents_sdk_integration.md
@@ -111,3 +111,28 @@ const agent = await GuardrailAgent.create(
 - Explore available guardrails for your use case  
 - Learn about pipeline configuration in our [quickstart](./quickstart.md)
 - For more details on the OpenAI Agents SDK, refer to the [Agent SDK documentation](https://openai.github.io/openai-agents-js/).
+
+## Token Usage Tracking
+
+!!! warning "JavaScript Agents SDK Limitation"
+    The JavaScript Agents SDK (`@openai/agents`) does not currently return guardrail results in the `RunResult` object. This means `totalGuardrailTokenUsage()` cannot retrieve token counts from Agents SDK runs.
+    
+    **For token usage tracking, use `GuardrailsOpenAI` instead of `GuardrailAgent`.** The Python Agents SDK does support this feature.
+
+When a guardrail **triggers** (throws `InputGuardrailTripwireTriggered` or `OutputGuardrailTripwireTriggered`), token usage IS available in the error's result object:
+
+```typescript
+try {
+  const result = await Runner.run(agent, userInput);
+} catch (error) {
+  if (error.constructor.name === 'InputGuardrailTripwireTriggered') {
+    // Token usage available when guardrail triggers
+    const usage = error.result?.output?.outputInfo?.token_usage;
+    if (usage) {
+      console.log(`Guardrail tokens: ${usage.total_tokens}`);
+    }
+  }
+}
+```
+
+For full token usage tracking across all guardrail runs (passing and failing), use the `GuardrailsOpenAI` client instead - see the [quickstart](./quickstart.md#token-usage-tracking) for details.

--- a/examples/basic/local_model.ts
+++ b/examples/basic/local_model.ts
@@ -2,7 +2,7 @@
  * Example: Guardrail bundle using Ollama's Gemma3 model with GuardrailsClient.
  */
 
-import { GuardrailsOpenAI, GuardrailTripwireTriggered } from '../../src';
+import { GuardrailsOpenAI, GuardrailTripwireTriggered, totalGuardrailTokenUsage } from '../../src';
 import * as readline from 'readline';
 import { OpenAI } from 'openai';
 
@@ -46,6 +46,10 @@ async function processInput(
     // Access response content using standard OpenAI API
     const responseContent = response.choices[0].message.content ?? '';
     console.log(`\nAssistant output: ${responseContent}\n`);
+    const usage = totalGuardrailTokenUsage(response);
+    if (usage.total_tokens !== null) {
+      console.log(`Token usage: ${usage.total_tokens}`);
+    }
 
     // Guardrails passed - now safe to add to conversation history
     conversation.push({ role: 'user', content: userInput });

--- a/examples/basic/multiturn_with_prompt_injection_detection.ts
+++ b/examples/basic/multiturn_with_prompt_injection_detection.ts
@@ -26,7 +26,12 @@
  */
 
 import * as readline from 'readline';
-import { GuardrailsOpenAI, GuardrailTripwireTriggered, GuardrailsResponse } from '../../src';
+import {
+  GuardrailsOpenAI,
+  GuardrailTripwireTriggered,
+  GuardrailsResponse,
+  totalGuardrailTokenUsage,
+} from '../../src';
 
 // Tool implementations (mocked)
 function get_horoscope(sign: string): { horoscope: string } {
@@ -299,6 +304,15 @@ async function main(malicious: boolean = false): Promise<void> {
 
         printGuardrailResults('initial', response);
 
+        const initialUsage = totalGuardrailTokenUsage(response);
+        if (initialUsage.total_tokens !== null) {
+          console.log(
+            `[dim]Guardrail tokens (initial): ${initialUsage.total_tokens} · prompt=${
+              initialUsage.prompt_tokens ?? 0
+            }, completion=${initialUsage.completion_tokens ?? 0}[/dim]`
+          );
+        }
+
         assistantOutputs = response.output ?? [];
 
         // Guardrails passed - now safe to add user message to conversation history
@@ -394,6 +408,14 @@ async function main(malicious: boolean = false): Promise<void> {
           });
 
           printGuardrailResults('final', response);
+          const finalUsage = totalGuardrailTokenUsage(response);
+          if (finalUsage.total_tokens !== null) {
+            console.log(
+              `[dim]Guardrail tokens (final): ${finalUsage.total_tokens} · prompt=${
+                finalUsage.prompt_tokens ?? 0
+              }, completion=${finalUsage.completion_tokens ?? 0}[/dim]`
+            );
+          }
           console.log(`\n🤖 Assistant: ${response.output_text}`);
 
           // Guardrails passed - now safe to add tool results and assistant responses to history

--- a/src/__tests__/unit/agents.test.ts
+++ b/src/__tests__/unit/agents.test.ts
@@ -451,7 +451,7 @@ describe('GuardrailAgent', () => {
       expect(result.outputInfo.input).toBe('Latest user message with additional context.');
     });
 
-  it('should handle guardrail execution errors based on raiseGuardrailErrors setting', async () => {
+    it('should handle guardrail execution errors based on raiseGuardrailErrors setting', async () => {
       process.env.OPENAI_API_KEY = 'test';
       const config = {
         version: 1,

--- a/src/__tests__/unit/agents.test.ts
+++ b/src/__tests__/unit/agents.test.ts
@@ -451,7 +451,7 @@ describe('GuardrailAgent', () => {
       expect(result.outputInfo.input).toBe('Latest user message with additional context.');
     });
 
-    it('should handle guardrail execution errors based on raiseGuardrailErrors setting', async () => {
+  it('should handle guardrail execution errors based on raiseGuardrailErrors setting', async () => {
       process.env.OPENAI_API_KEY = 'test';
       const config = {
         version: 1,
@@ -545,6 +545,70 @@ describe('GuardrailAgent', () => {
       await expect(guardrailFunctionStrict.execute('test')).rejects.toThrow(
         'Guardrail execution failed'
       );
+    });
+  });
+
+  it('propagates guardrail metadata to outputInfo on success', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    const config = {
+      version: 1,
+      input: {
+        version: 1,
+        guardrails: [{ name: 'Jailbreak', config: {} }],
+      },
+    };
+
+    const { instantiateGuardrails } = await import('../../runtime');
+    vi.mocked(instantiateGuardrails).mockImplementationOnce(() =>
+      Promise.resolve([
+        {
+          definition: {
+            name: 'Jailbreak',
+            description: 'Test guardrail',
+            mediaType: 'text/plain',
+            configSchema: z.object({}),
+            checkFn: vi.fn(),
+            metadata: {},
+            ctxRequirements: z.object({}),
+            schema: () => ({}),
+            instantiate: vi.fn(),
+          },
+          config: {},
+          run: vi.fn().mockResolvedValue({
+            tripwireTriggered: false,
+            info: {
+              guardrail_name: 'Jailbreak',
+              flagged: false,
+              token_usage: {
+                prompt_tokens: 42,
+                completion_tokens: 10,
+                total_tokens: 52,
+              },
+            },
+          }),
+        } as unknown as Parameters<typeof instantiateGuardrails>[0] extends Promise<infer T>
+          ? T extends readonly (infer U)[]
+            ? U
+            : never
+          : never,
+      ])
+    );
+
+    const agent = (await GuardrailAgent.create(
+      config,
+      'Metadata Agent',
+      'Test instructions'
+    )) as MockAgent;
+
+    const guardrailFunction = agent.inputGuardrails[0];
+    const result = await guardrailFunction.execute('payload');
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.outputInfo.guardrail_name).toBe('Jailbreak');
+    expect(result.outputInfo.token_usage).toEqual({
+      prompt_tokens: 42,
+      completion_tokens: 10,
+      total_tokens: 52,
     });
   });
 });

--- a/src/__tests__/unit/base-client.test.ts
+++ b/src/__tests__/unit/base-client.test.ts
@@ -368,3 +368,64 @@ describe('GuardrailsBaseClient helpers', () => {
     });
   });
 });
+
+describe('GuardrailResultsImpl token usage', () => {
+  it('aggregates usage across all stages', () => {
+    const results = new GuardrailResultsImpl(
+      [
+        {
+          tripwireTriggered: false,
+          info: {
+            guardrail_name: 'Jailbreak',
+            token_usage: {
+              prompt_tokens: 100,
+              completion_tokens: 40,
+              total_tokens: 140,
+            },
+          },
+        },
+      ],
+      [],
+      [
+        {
+          tripwireTriggered: false,
+          info: {
+            guardrail_name: 'NSFW',
+            token_usage: {
+              prompt_tokens: 50,
+              completion_tokens: 30,
+              total_tokens: 80,
+            },
+          },
+        },
+      ]
+    );
+
+    expect(results.totalTokenUsage).toEqual({
+      prompt_tokens: 150,
+      completion_tokens: 70,
+      total_tokens: 220,
+    });
+  });
+
+  it('returns null totals when no guardrail reports usage', () => {
+    const results = new GuardrailResultsImpl(
+      [
+        {
+          tripwireTriggered: false,
+          info: {
+            guardrail_name: 'Moderation',
+          },
+        },
+      ],
+      [],
+      []
+    );
+
+    expect(results.totalTokenUsage).toEqual({
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+    });
+  });
+});

--- a/src/__tests__/unit/llm-base.test.ts
+++ b/src/__tests__/unit/llm-base.test.ts
@@ -186,11 +186,11 @@ describe('LLM Base', () => {
       expect(result.info.flagged).toBe(false);
       expect(result.info.confidence).toBe(0.0);
       expect(result.info.error_message).toBe('LLM response validation failed.');
+      // Token usage is now preserved even when schema validation fails
       expect(result.info.token_usage).toEqual({
-        prompt_tokens: null,
-        completion_tokens: null,
-        total_tokens: null,
-        unavailable_reason: 'LLM call failed before usage could be recorded',
+        prompt_tokens: 12,
+        completion_tokens: 4,
+        total_tokens: 16,
       });
     });
 
@@ -235,11 +235,11 @@ describe('LLM Base', () => {
       expect(result.info.flagged).toBe(false);
       expect(result.info.confidence).toBe(0.0);
       expect(result.info.error_message).toBe('LLM returned non-JSON or malformed JSON.');
+      // Token usage is now preserved even when JSON parsing fails
       expect(result.info.token_usage).toEqual({
-        prompt_tokens: null,
-        completion_tokens: null,
-        total_tokens: null,
-        unavailable_reason: 'LLM call failed before usage could be recorded',
+        prompt_tokens: 8,
+        completion_tokens: 3,
+        total_tokens: 11,
       });
     });
   });

--- a/src/__tests__/unit/llm-base.test.ts
+++ b/src/__tests__/unit/llm-base.test.ts
@@ -118,6 +118,11 @@ describe('LLM Base', () => {
                     },
                   },
                 ],
+                usage: {
+                  prompt_tokens: 20,
+                  completion_tokens: 10,
+                  total_tokens: 30,
+                },
               }),
             },
           },
@@ -133,6 +138,11 @@ describe('LLM Base', () => {
       expect(result.info.guardrail_name).toBe('Test Guardrail');
       expect(result.info.flagged).toBe(true);
       expect(result.info.confidence).toBe(0.8);
+      expect(result.info.token_usage).toEqual({
+        prompt_tokens: 20,
+        completion_tokens: 10,
+        total_tokens: 30,
+      });
     });
 
     it('should fail open on schema validation error and not trigger tripwire', async () => {
@@ -155,6 +165,11 @@ describe('LLM Base', () => {
                     },
                   },
                 ],
+                usage: {
+                  prompt_tokens: 12,
+                  completion_tokens: 4,
+                  total_tokens: 16,
+                },
               }),
             },
           },
@@ -170,7 +185,13 @@ describe('LLM Base', () => {
       expect(result.executionFailed).toBe(true);
       expect(result.info.flagged).toBe(false);
       expect(result.info.confidence).toBe(0.0);
-      expect(result.info.info.error_message).toBe('LLM response validation failed.');
+      expect(result.info.error_message).toBe('LLM response validation failed.');
+      expect(result.info.token_usage).toEqual({
+        prompt_tokens: null,
+        completion_tokens: null,
+        total_tokens: null,
+        unavailable_reason: 'LLM call failed before usage could be recorded',
+      });
     });
 
     it('should fail open on malformed JSON and not trigger tripwire', async () => {
@@ -193,6 +214,11 @@ describe('LLM Base', () => {
                     },
                   },
                 ],
+                usage: {
+                  prompt_tokens: 8,
+                  completion_tokens: 3,
+                  total_tokens: 11,
+                },
               }),
             },
           },
@@ -208,7 +234,13 @@ describe('LLM Base', () => {
       expect(result.executionFailed).toBe(true);
       expect(result.info.flagged).toBe(false);
       expect(result.info.confidence).toBe(0.0);
-      expect(result.info.info.error_message).toBe('LLM returned non-JSON or malformed JSON.');
+      expect(result.info.error_message).toBe('LLM returned non-JSON or malformed JSON.');
+      expect(result.info.token_usage).toEqual({
+        prompt_tokens: null,
+        completion_tokens: null,
+        total_tokens: null,
+        unavailable_reason: 'LLM call failed before usage could be recorded',
+      });
     });
   });
 });

--- a/src/__tests__/unit/prompt_injection_detection.test.ts
+++ b/src/__tests__/unit/prompt_injection_detection.test.ts
@@ -132,6 +132,7 @@ describe('Prompt Injection Detection Check', () => {
     expect(result.info.confidence).toBeLessThan(config.confidence_threshold);
     expect(result.info.guardrail_name).toBe('Prompt Injection Detection');
     expect(result.info.evidence).toBeNull();
+    expect(result.info.token_usage).toBeDefined();
   });
 
   it('should handle context with previous messages', async () => {

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -13,6 +13,8 @@ import {
   Message,
   ContentPart,
   TextContentPart,
+  TokenUsageSummary,
+  aggregateTokenUsageFromInfos,
 } from './types';
 import { ContentUtils } from './utils/content';
 import {
@@ -81,6 +83,7 @@ export interface GuardrailResults {
   readonly allResults: GuardrailResult[];
   readonly tripwiresTriggered: boolean;
   readonly triggeredResults: GuardrailResult[];
+  readonly totalTokenUsage: TokenUsageSummary;
 }
 
 /**
@@ -103,6 +106,10 @@ export class GuardrailResultsImpl implements GuardrailResults {
 
   get triggeredResults(): GuardrailResult[] {
     return this.allResults.filter((r) => r.tripwireTriggered);
+  }
+
+  get totalTokenUsage(): TokenUsageSummary {
+    return aggregateTokenUsageFromInfos(this.allResults.map((result) => result.info));
   }
 }
 

--- a/src/checks/llm-base.ts
+++ b/src/checks/llm-base.ts
@@ -455,7 +455,7 @@ export function createLLMCheckFn(
     );
 
     if (isLLMErrorOutput(analysis)) {
-      return createErrorResult(name, analysis, undefined, tokenUsage);
+      return createErrorResult(name, analysis, {}, tokenUsage);
     }
 
     const isTrigger = analysis.flagged && analysis.confidence >= config.confidence_threshold;

--- a/src/checks/llm-base.ts
+++ b/src/checks/llm-base.ts
@@ -291,6 +291,10 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     unavailable_reason: 'LLM call failed before usage could be recorded',
   });
 
+  // Declare tokenUsage outside try block so it's accessible in catch
+  // when JSON parsing or schema validation fails after a successful API call
+  let tokenUsage: TokenUsage = noUsage;
+
   try {
     // Handle temperature based on model capabilities
     let temperature = 0.0;
@@ -319,7 +323,8 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     // @ts-ignore - safety_identifier is not in the OpenAI types yet
     const response = await client.chat.completions.create(params);
 
-    const tokenUsage = extractTokenUsage(response);
+    // Extract token usage immediately after API call so it's available even if parsing fails
+    tokenUsage = extractTokenUsage(response);
     const result = response.choices[0]?.message?.content;
     if (!result) {
       return [
@@ -356,6 +361,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     }
 
     // Fail-open on JSON parsing errors (malformed or non-JSON responses)
+    // Use tokenUsage here since API call succeeded but response parsing failed
     if (error instanceof SyntaxError || (error as Error)?.constructor?.name === 'SyntaxError') {
       console.warn('LLM returned non-JSON or malformed JSON.', error);
       return [
@@ -366,11 +372,12 @@ export async function runLLM<TOutput extends ZodTypeAny>(
             error_message: 'LLM returned non-JSON or malformed JSON.',
           },
         }),
-        noUsage,
+        tokenUsage,
       ];
     }
 
     // Fail-open on schema validation errors (e.g., wrong types like confidence as string)
+    // Use tokenUsage here since API call succeeded but schema validation failed
     if (error instanceof z.ZodError) {
       console.warn('LLM response validation failed.', error);
       return [
@@ -382,7 +389,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
             zod_issues: error.issues ?? [],
           },
         }),
-        noUsage,
+        tokenUsage,
       ];
     }
 

--- a/src/checks/llm-base.ts
+++ b/src/checks/llm-base.ts
@@ -9,7 +9,14 @@
 
 import { z, ZodTypeAny } from 'zod';
 import { OpenAI } from 'openai';
-import { CheckFn, GuardrailResult, GuardrailLLMContext } from '../types';
+import {
+  CheckFn,
+  GuardrailResult,
+  GuardrailLLMContext,
+  TokenUsage,
+  extractTokenUsage,
+  tokenUsageToDict,
+} from '../types';
 import { defaultSpecRegistry } from '../registry';
 import { SAFETY_IDENTIFIER, supportsSafetyIdentifier } from '../utils/safety-identifier';
 
@@ -78,7 +85,8 @@ export type LLMErrorOutput = z.infer<typeof LLMErrorOutput>;
 export function createErrorResult(
   guardrailName: string,
   analysis: LLMErrorOutput,
-  additionalInfo: Record<string, unknown> = {}
+  additionalInfo: Record<string, unknown> = {},
+  tokenUsage?: TokenUsage
 ): GuardrailResult {
   return {
     tripwireTriggered: false,
@@ -90,6 +98,7 @@ export function createErrorResult(
       confidence: analysis.confidence,
       ...analysis.info,
       ...additionalInfo,
+      ...(tokenUsage ? { token_usage: tokenUsageToDict(tokenUsage) } : {}),
     },
   };
 }
@@ -273,8 +282,14 @@ export async function runLLM<TOutput extends ZodTypeAny>(
   client: OpenAI,
   model: string,
   outputModel: TOutput
-): Promise<z.infer<TOutput> | LLMErrorOutput> {
+): Promise<[z.infer<TOutput> | LLMErrorOutput, TokenUsage]> {
   const fullPrompt = buildFullPrompt(systemPrompt, outputModel);
+  const noUsage: TokenUsage = Object.freeze({
+    prompt_tokens: null,
+    completion_tokens: null,
+    total_tokens: null,
+    unavailable_reason: 'LLM call failed before usage could be recorded',
+  });
 
   try {
     // Handle temperature based on model capabilities
@@ -304,68 +319,84 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     // @ts-ignore - safety_identifier is not in the OpenAI types yet
     const response = await client.chat.completions.create(params);
 
+    const tokenUsage = extractTokenUsage(response);
     const result = response.choices[0]?.message?.content;
     if (!result) {
-      return LLMErrorOutput.parse({
-        flagged: false,
-        confidence: 0.0,
-        info: {
-          error_message: 'LLM returned no content',
-        },
-      });
+      return [
+        LLMErrorOutput.parse({
+          flagged: false,
+          confidence: 0.0,
+          info: {
+            error_message: 'LLM returned no content',
+          },
+        }),
+        tokenUsage,
+      ];
     }
 
     const cleanedResult = stripJsonCodeFence(result);
-    return outputModel.parse(JSON.parse(cleanedResult));
+    return [outputModel.parse(JSON.parse(cleanedResult)), tokenUsage];
   } catch (error) {
     console.error('LLM guardrail failed for prompt:', systemPrompt, error);
 
     // Check if this is a content filter error - Azure OpenAI
     if (error && typeof error === 'string' && error.includes('content_filter')) {
       console.warn('Content filter triggered by provider:', error);
-      return LLMErrorOutput.parse({
-        flagged: true,
-        confidence: 1.0,
-        info: {
-          third_party_filter: true,
-          error_message: String(error),
-        },
-      });
+      return [
+        LLMErrorOutput.parse({
+          flagged: true,
+          confidence: 1.0,
+          info: {
+            third_party_filter: true,
+            error_message: String(error),
+          },
+        }),
+        noUsage,
+      ];
     }
 
     // Fail-open on JSON parsing errors (malformed or non-JSON responses)
     if (error instanceof SyntaxError || (error as Error)?.constructor?.name === 'SyntaxError') {
       console.warn('LLM returned non-JSON or malformed JSON.', error);
-      return LLMErrorOutput.parse({
-        flagged: false,
-        confidence: 0.0,
-        info: {
-          error_message: 'LLM returned non-JSON or malformed JSON.',
-        },
-      });
+      return [
+        LLMErrorOutput.parse({
+          flagged: false,
+          confidence: 0.0,
+          info: {
+            error_message: 'LLM returned non-JSON or malformed JSON.',
+          },
+        }),
+        noUsage,
+      ];
     }
 
     // Fail-open on schema validation errors (e.g., wrong types like confidence as string)
     if (error instanceof z.ZodError) {
       console.warn('LLM response validation failed.', error);
-      return LLMErrorOutput.parse({
-        flagged: false,
-        confidence: 0.0,
-        info: {
-          error_message: 'LLM response validation failed.',
-          zod_issues: error.issues ?? [],
-        },
-      });
+      return [
+        LLMErrorOutput.parse({
+          flagged: false,
+          confidence: 0.0,
+          info: {
+            error_message: 'LLM response validation failed.',
+            zod_issues: error.issues ?? [],
+          },
+        }),
+        noUsage,
+      ];
     }
 
     // Always return error information for other LLM failures
-    return LLMErrorOutput.parse({
-      flagged: false,
-      confidence: 0.0,
-      info: {
-        error_message: String(error),
-      },
-    });
+    return [
+      LLMErrorOutput.parse({
+        flagged: false,
+        confidence: 0.0,
+        info: {
+          error_message: String(error),
+        },
+      }),
+      noUsage,
+    ];
   }
 }
 
@@ -408,7 +439,7 @@ export function createLLMCheckFn(
       );
     }
 
-    const analysis = await runLLM(
+    const [analysis, tokenUsage] = await runLLM(
       data,
       renderedSystemPrompt,
       ctx.guardrailLlm as OpenAI, // Type assertion to handle OpenAI client compatibility
@@ -417,15 +448,7 @@ export function createLLMCheckFn(
     );
 
     if (isLLMErrorOutput(analysis)) {
-      return {
-        tripwireTriggered: false,
-        executionFailed: true,
-        originalException: new Error(String(analysis.info?.error_message || 'LLM execution failed')),
-        info: {
-          guardrail_name: name,
-          ...analysis,
-        },
-      };
+      return createErrorResult(name, analysis, undefined, tokenUsage);
     }
 
     const isTrigger = analysis.flagged && analysis.confidence >= config.confidence_threshold;
@@ -435,6 +458,7 @@ export function createLLMCheckFn(
         guardrail_name: name,
         ...analysis,
         threshold: config.confidence_threshold,
+        token_usage: tokenUsageToDict(tokenUsage),
       },
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
  */
 
 // Core types and interfaces
-export { GuardrailResult, GuardrailLLMContext, CheckFn } from './types';
+export { GuardrailResult, GuardrailLLMContext, CheckFn, totalGuardrailTokenUsage } from './types';
 
 // Exception types
 export {
@@ -65,4 +65,4 @@ export { GuardrailAgent } from './agents';
 export { main as cli } from './cli';
 
 // Re-export commonly used types
-export type { MaybeAwaitableResult } from './types';
+export type { MaybeAwaitableResult, TokenUsage, TokenUsageSummary } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,3 +155,249 @@ export type TextOnlyMessage = {
 
 /** Array of text-only messages */
 export type TextOnlyMessageArray = TextOnlyMessage[];
+
+/**
+ * Token usage statistics emitted by LLM-based guardrails.
+ */
+export type TokenUsage = Readonly<{
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+  total_tokens: number | null;
+  unavailable_reason?: string | null;
+}>;
+
+/**
+ * Aggregated token usage summary across multiple guardrails.
+ */
+export type TokenUsageSummary = Readonly<{
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+  total_tokens: number | null;
+}>;
+
+type UsageRecord = {
+  prompt_tokens?: unknown;
+  completion_tokens?: unknown;
+  total_tokens?: unknown;
+  input_tokens?: unknown;
+  output_tokens?: unknown;
+};
+
+const EMPTY_TOKEN_USAGE_SUMMARY: TokenUsageSummary = Object.freeze({
+  prompt_tokens: null,
+  completion_tokens: null,
+  total_tokens: null,
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isIterable(value: unknown): value is Iterable<unknown> {
+  return typeof value === 'object' && value !== null && typeof (value as Iterable<unknown>)[Symbol.iterator] === 'function';
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function pickNumber(record: UsageRecord | null | undefined, keys: (keyof UsageRecord)[]): number | null {
+  if (!record) {
+    return null;
+  }
+
+  for (const key of keys) {
+    const candidate = record[key];
+    const numeric = readNumber(candidate);
+    if (numeric !== null) {
+      return numeric;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract token usage data from an OpenAI API response object.
+ */
+export function extractTokenUsage(response: unknown): TokenUsage {
+  const usage = (response as { usage?: UsageRecord | null })?.usage;
+  if (!usage) {
+    return Object.freeze({
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      unavailable_reason: 'Token usage not available for this model provider',
+    }) as TokenUsage;
+  }
+
+  const promptTokens = pickNumber(usage, ['prompt_tokens', 'input_tokens']);
+  const completionTokens = pickNumber(usage, ['completion_tokens', 'output_tokens']);
+  const totalTokens = pickNumber(usage, ['total_tokens']);
+
+  if (promptTokens === null && completionTokens === null && totalTokens === null) {
+    return Object.freeze({
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      unavailable_reason: 'Token usage data not populated in response',
+    }) as TokenUsage;
+  }
+
+  return Object.freeze({
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: totalTokens,
+  }) as TokenUsage;
+}
+
+/**
+ * Convert a TokenUsage object into a plain dictionary suitable for serialization.
+ */
+export function tokenUsageToDict(tokenUsage: TokenUsage): TokenUsage {
+  const result: Record<string, number | null> & { unavailable_reason?: string | null } = {
+    prompt_tokens: tokenUsage.prompt_tokens,
+    completion_tokens: tokenUsage.completion_tokens,
+    total_tokens: tokenUsage.total_tokens,
+  };
+
+  if (tokenUsage.unavailable_reason !== undefined) {
+    result.unavailable_reason = tokenUsage.unavailable_reason;
+  }
+
+  return Object.freeze(result) as TokenUsage;
+}
+
+/**
+ * Aggregate token usage values from a collection of guardrail info dictionaries.
+ */
+export function aggregateTokenUsageFromInfos(
+  infoDicts: Iterable<Record<string, unknown> | null | undefined>
+): TokenUsageSummary {
+  let totalPrompt = 0;
+  let totalCompletion = 0;
+  let totalTokens = 0;
+  let hasData = false;
+
+  for (const info of infoDicts) {
+    if (!info) {
+      continue;
+    }
+
+    const usage = info.token_usage;
+    if (!isRecord(usage)) {
+      continue;
+    }
+
+    const prompt = readNumber(usage.prompt_tokens);
+    const completion = readNumber(usage.completion_tokens);
+    const total = readNumber(usage.total_tokens);
+
+    if (prompt === null && completion === null && total === null) {
+      continue;
+    }
+
+    hasData = true;
+    if (prompt !== null) {
+      totalPrompt += prompt;
+    }
+    if (completion !== null) {
+      totalCompletion += completion;
+    }
+    if (total !== null) {
+      totalTokens += total;
+    }
+  }
+
+  if (!hasData) {
+    return EMPTY_TOKEN_USAGE_SUMMARY;
+  }
+
+  return Object.freeze({
+    prompt_tokens: totalPrompt,
+    completion_tokens: totalCompletion,
+    total_tokens: totalTokens,
+  }) as TokenUsageSummary;
+}
+
+const AGENT_RESULT_ATTRS = [
+  'input_guardrail_results',
+  'output_guardrail_results',
+  'tool_input_guardrail_results',
+  'tool_output_guardrail_results',
+  'inputGuardrailResults',
+  'outputGuardrailResults',
+  'toolInputGuardrailResults',
+  'toolOutputGuardrailResults',
+] as const;
+
+function extractAgentsSdkInfos(stageResults: unknown): Record<string, unknown>[] {
+  if (!stageResults) {
+    return [];
+  }
+
+  const entries: unknown[] = Array.isArray(stageResults)
+    ? stageResults
+    : isIterable(stageResults)
+      ? Array.from(stageResults as Iterable<unknown>)
+      : [];
+
+  const infos: Record<string, unknown>[] = [];
+  for (const entry of entries) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+
+    const direct = entry.output_info ?? entry.outputInfo;
+    if (isRecord(direct)) {
+      infos.push(direct);
+      continue;
+    }
+
+    const output = entry.output;
+    if (isRecord(output)) {
+      const nested = output.output_info ?? output.outputInfo;
+      if (isRecord(nested)) {
+        infos.push(nested);
+      }
+    }
+  }
+
+  return infos;
+}
+
+/**
+ * Unified helper to compute total guardrail token usage from any result shape.
+ */
+export function totalGuardrailTokenUsage(result: unknown): TokenUsageSummary {
+  if (!isRecord(result)) {
+    return EMPTY_TOKEN_USAGE_SUMMARY;
+  }
+
+  const guardrailResults = result.guardrail_results ?? result.guardrailResults;
+  if (isRecord(guardrailResults)) {
+    const totals = (guardrailResults as { totalTokenUsage?: TokenUsageSummary }).totalTokenUsage;
+    if (totals) {
+      return totals;
+    }
+  }
+
+  const directTotals = (result as { totalTokenUsage?: TokenUsageSummary }).totalTokenUsage;
+  if (directTotals) {
+    return directTotals;
+  }
+
+  const infos: Record<string, unknown>[] = [];
+  for (const attr of AGENT_RESULT_ATTRS) {
+    const stageResults = result[attr];
+    if (stageResults) {
+      infos.push(...extractAgentsSdkInfos(stageResults));
+    }
+  }
+
+  if (infos.length === 0) {
+    return EMPTY_TOKEN_USAGE_SUMMARY;
+  }
+
+  return aggregateTokenUsageFromInfos(infos);
+}


### PR DESCRIPTION
Implements an update for [issue 41](https://github.com/openai/openai-guardrails-python/issues/41)
- For Guardrails that use LLM's, return token usage data
- Per guardrail token usage is returned via its `info_dict` and can be accessed with 
```
const response = await client.guardrails.responses.create(...);
for (const gr of response.guardrail_results.allResults) {
  const usage = gr.info.token_usage;
  if (usage) {
    console.log(`${gr.info.guardrail_name}: ${usage.total_tokens} tokens`);
  }
}
```

- Additionally, the total tokens used in a response can be returned with the `totalGuardrailTokenUsage` helper
`totalGuardrailTokenUsage(response)`. This works for all clients (`GuardrailAgent`, `GuardrailAsyncOpenAI`, ...) and works with streaming and non-streaming
- Updated the documentation to reflect this new functionality
- Updated example scripts to show implementation
- Added tests

**Note:** Known limitation, we do not return the token count for `GuardrailAgent`. OpenAI's Agent SDK JS version is slightly different from the Python implementation. The RunResult does not contain details about the guardrail results so we can not pass token count back. This is noted in our Quickstart.