### PR TITLE
Add RequestOptions parameter to responses and chat create methods

### DIFF
--- a/src/__tests__/unit/chat-resources.test.ts
+++ b/src/__tests__/unit/chat-resources.test.ts
@@ -96,7 +96,7 @@ describe('Chat resource', () => {
       model: 'gpt-4',
       stream: false,
       safety_identifier: 'openai-guardrails-js',
-    });
+    }, undefined);
     expect(client.handleLlmResponse).toHaveBeenCalledWith(
       { id: 'chat-response' },
       [{ stage: 'preflight' }],
@@ -157,7 +157,7 @@ describe('Responses resource', () => {
       stream: false,
       tools: undefined,
       safety_identifier: 'openai-guardrails-js',
-    });
+    }, undefined);
     expect(client.handleLlmResponse).toHaveBeenCalledWith(
       { id: 'responses-api' },
       [{ stage: 'preflight' }],

--- a/src/resources/chat/chat.ts
+++ b/src/resources/chat/chat.ts
@@ -40,7 +40,8 @@ export class ChatCompletions {
       model: string;
       stream: true;
       suppressTripwire?: boolean;
-    } & Omit<OpenAI.Chat.Completions.ChatCompletionCreateParams, 'messages' | 'model' | 'stream'>
+    } & Omit<OpenAI.Chat.Completions.ChatCompletionCreateParams, 'messages' | 'model' | 'stream'>,
+    options?: OpenAI.RequestOptions,
   ): Promise<AsyncIterableIterator<GuardrailsResponse>>;
 
   // Overload: non-streaming (default)
@@ -50,7 +51,8 @@ export class ChatCompletions {
       model: string;
       stream?: false;
       suppressTripwire?: boolean;
-    } & Omit<OpenAI.Chat.Completions.ChatCompletionCreateParams, 'messages' | 'model' | 'stream'>
+    } & Omit<OpenAI.Chat.Completions.ChatCompletionCreateParams, 'messages' | 'model' | 'stream'>,
+    options?: OpenAI.RequestOptions,
   ): Promise<GuardrailsResponse<OpenAI.Chat.Completions.ChatCompletion>>;
 
   async create(
@@ -59,7 +61,8 @@ export class ChatCompletions {
       model: string;
       stream?: boolean;
       suppressTripwire?: boolean;
-    } & Omit<OpenAI.Chat.Completions.ChatCompletionCreateParams, 'messages' | 'model' | 'stream'>
+    } & Omit<OpenAI.Chat.Completions.ChatCompletionCreateParams, 'messages' | 'model' | 'stream'>,
+    options?: OpenAI.RequestOptions,
   ): Promise<GuardrailsResponse<OpenAI.Chat.Completions.ChatCompletion> | AsyncIterableIterator<GuardrailsResponse>> {
     const { messages, model, stream = false, suppressTripwire = false, ...kwargs } = params;
 
@@ -109,7 +112,7 @@ export class ChatCompletions {
         suppressTripwire,
         this.client.raiseGuardrailErrors
       ),
-      resourceClient.chat.completions.create(apiParams),
+      resourceClient.chat.completions.create(apiParams, options),
     ]);
 
     // Handle streaming vs non-streaming

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -27,7 +27,8 @@ export class Responses {
       stream: true;
       tools?: unknown[];
       suppressTripwire?: boolean;
-    } & Omit<OpenAI.Responses.ResponseCreateParams, 'input' | 'model' | 'stream' | 'tools'>
+    } & Omit<OpenAI.Responses.ResponseCreateParams, 'input' | 'model' | 'stream' | 'tools'>,
+    options?: OpenAI.RequestOptions,
   ): Promise<AsyncIterableIterator<GuardrailsResponse>>;
 
   // Overload: non-streaming (default)
@@ -38,7 +39,8 @@ export class Responses {
       stream?: false;
       tools?: unknown[];
       suppressTripwire?: boolean;
-    } & Omit<OpenAI.Responses.ResponseCreateParams, 'input' | 'model' | 'stream' | 'tools'>
+    } & Omit<OpenAI.Responses.ResponseCreateParams, 'input' | 'model' | 'stream' | 'tools'>,
+    options?: OpenAI.RequestOptions,
   ): Promise<GuardrailsResponse<OpenAI.Responses.Response>>;
 
   async create(
@@ -48,7 +50,8 @@ export class Responses {
       stream?: boolean;
       tools?: unknown[];
       suppressTripwire?: boolean;
-    } & Omit<OpenAI.Responses.ResponseCreateParams, 'input' | 'model' | 'stream' | 'tools'>
+    } & Omit<OpenAI.Responses.ResponseCreateParams, 'input' | 'model' | 'stream' | 'tools'>,
+    options?: OpenAI.RequestOptions,
   ): Promise<GuardrailsResponse<OpenAI.Responses.Response> | AsyncIterableIterator<GuardrailsResponse>> {
     const { input, model, stream = false, tools, suppressTripwire = false, ...kwargs } = params;
 
@@ -112,7 +115,7 @@ export class Responses {
         suppressTripwire,
         this.client.raiseGuardrailErrors
       ),
-      resourceClient.responses.create(apiParams),
+      resourceClient.responses.create(apiParams, options),
     ]);
 
     // Handle streaming vs non-streaming


### PR DESCRIPTION
Fixes #62

The `responses.create()` and `chat.completions.create()` wrappers were missing the second `options` parameter that the underlying OpenAI SDK accepts. This prevented users from passing `RequestOptions` (e.g. `signal` from an `AbortController`) to control in-flight requests.

### Changes

- Added `options?: OpenAI.RequestOptions` as a second parameter to all overload signatures in `Responses.create()` and `ChatCompletions.create()`
- Forward `options` to the underlying `resourceClient.*.create()` calls
- Updated test assertions to reflect the forwarded parameter

### Use case

When a guardrail trips, the caller may want to abort the concurrent LLM request:

```ts
const controller = new AbortController();

const result = await client.responses.create(
  { input: "...", model: "gpt-4o" },
  { signal: controller.signal },
);
```

Without this change, the `signal` had no way to reach the underlying fetch request, causing the Node.js process to hang until the LLM call completed on its own.