### PR TITLE
fix: prevent crash when logging malformed error objects

### DIFF
--- a/src/__tests__/unit/llm-base.test.ts
+++ b/src/__tests__/unit/llm-base.test.ts
@@ -418,6 +418,37 @@ describe('LLM Base', () => {
       });
     });
 
+    it('should not crash when LLM throws a malformed error object', async () => {
+      const guardrail = createLLMCheckFn(
+        'Malformed Error Guardrail',
+        'Ensures malformed errors do not crash logging',
+        'Test system prompt'
+      );
+
+      // Simulate an error object that would crash Node's util.inspect
+      const malformedError = Object.create(null);
+
+      const mockContext = {
+        guardrailLlm: {
+          chat: {
+            completions: {
+              create: vi.fn().mockRejectedValue(malformedError),
+            },
+          },
+        },
+      };
+
+      const result = await guardrail(mockContext as unknown as GuardrailLLMContext, 'test text', {
+        model: 'gpt-4',
+        confidence_threshold: 0.7,
+      });
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.executionFailed).toBe(true);
+      expect(result.info.flagged).toBe(false);
+      expect(result.info.confidence).toBe(0.0);
+    });
+
     it('should not include reasoning by default (include_reasoning=false)', async () => {
       const guardrail = createLLMCheckFn(
         'Test Guardrail Without Reasoning',

--- a/src/checks/llm-base.ts
+++ b/src/checks/llm-base.ts
@@ -23,6 +23,21 @@ import { SAFETY_IDENTIFIER, supportsSafetyIdentifier } from '../utils/safety-ide
 import { NormalizedConversationEntry } from '../utils/conversation';
 
 /**
+ * Safely convert an error to a loggable string, avoiding crashes from
+ * malformed objects that break Node's util.inspect formatting.
+ */
+function safeErrorString(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+/**
  * Default maximum number of conversation turns to include for multi-turn analysis.
  */
 export const DEFAULT_MAX_TURNS = 10;
@@ -450,18 +465,18 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     const cleanedResult = stripJsonCodeFence(result);
     return [outputModel.parse(JSON.parse(cleanedResult)), tokenUsage];
   } catch (error) {
-    console.error('LLM guardrail failed for prompt:', systemPrompt, error);
+    console.error('LLM guardrail failed for prompt:', systemPrompt, safeErrorString(error));
 
     // Check if this is a content filter error - Azure OpenAI
     if (error && typeof error === 'string' && error.includes('content_filter')) {
-      console.warn('Content filter triggered by provider:', error);
+      console.warn('Content filter triggered by provider:', safeErrorString(error));
       return [
         LLMErrorOutput.parse({
           flagged: true,
           confidence: 1.0,
           info: {
             third_party_filter: true,
-            error_message: String(error),
+            error_message: safeErrorString(error),
           },
         }),
         noUsage,
@@ -471,7 +486,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     // Fail-open on JSON parsing errors (malformed or non-JSON responses)
     // Use tokenUsage here since API call succeeded but response parsing failed
     if (error instanceof SyntaxError || (error as Error)?.constructor?.name === 'SyntaxError') {
-      console.warn('LLM returned non-JSON or malformed JSON.', error);
+      console.warn('LLM returned non-JSON or malformed JSON.', safeErrorString(error));
       return [
         LLMErrorOutput.parse({
           flagged: false,
@@ -487,7 +502,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     // Fail-open on schema validation errors (e.g., wrong types like confidence as string)
     // Use tokenUsage here since API call succeeded but schema validation failed
     if (error instanceof z.ZodError) {
-      console.warn('LLM response validation failed.', error);
+      console.warn('LLM response validation failed.', safeErrorString(error));
       return [
         LLMErrorOutput.parse({
           flagged: false,
@@ -507,7 +522,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
         flagged: false,
         confidence: 0.0,
         info: {
-          error_message: String(error),
+          error_message: safeErrorString(error),
         },
       }),
       noUsage,


### PR DESCRIPTION
## Summary

- Add `safeErrorString()` helper that safely converts errors to loggable strings without crashing Node's `util.inspect`
- Replace all raw `error` references in `console.error`/`console.warn` calls and `String(error)` conversions in `src/checks/llm-base.ts` with the safe helper
- Add test verifying null-prototype error objects no longer crash the library

## Problem

When `runLLM` catches an error with a malformed structure (e.g. empty objects, null-prototype objects, or circular references), passing it directly to `console.error()` crashes Node's `util.inspect` with `TypeError: Cannot read properties of undefined (reading 'value')`. Similarly, `String(error)` crashes with `Cannot convert object to primitive value` on null-prototype objects.

This affects all error logging paths in the catch block (lines 453, 457, 474, 490) and error message serialization (lines 479, 525).

## Fix

A small `safeErrorString()` function:
1. `Error` instances → use `error.stack` or `error.message`
2. Other objects → `JSON.stringify()` with try-catch fallback to `String()`

## Test plan

- [x] Added unit test throwing `Object.create(null)` — verifies no crash, fail-open preserved
- [x] All 349 existing tests pass
- [x] TypeScript compiles cleanly

Fixes #60