### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install dependencies


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `astral-sh/setup-uv` | [`v5`](https://github.com/astral-sh/setup-uv/releases/tag/v5) | [`v7`](https://github.com/astral-sh/setup-uv/releases/tag/v7) | [Release](https://github.com/astral-sh/setup-uv/releases/tag/v7) | docs.yml |

## Breaking Changes

- **astral-sh/setup-uv** (v5 → v7): Major version upgrade — review the [release notes](https://github.com/astral-sh/setup-uv/releases) for breaking changes

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
