### PR TITLE
fix: control-character URL parser differentials

### DIFF
--- a/src/__tests__/unit/checks/keywords-urls.test.ts
+++ b/src/__tests__/unit/checks/keywords-urls.test.ts
@@ -271,17 +271,20 @@ describe('UrlsConfig', () => {
 });
 
 describe('urls guardrail', () => {
+  const defaultUrlConfig = {
+    url_allow_list: [],
+    allowed_schemes: new Set(['https']),
+    block_userinfo: true,
+    allow_subdomains: false,
+  };
+
   it('allows https URLs listed in the allow list', async () => {
-    const result = await urls(
-      {},
-      'Visit https://example.com/docs for docs.',
-      {
-        url_allow_list: ['example.com'],
-        allowed_schemes: new Set(['https']),
-        block_userinfo: true,
-        allow_subdomains: false,
-      }
-    );
+    const result = await urls({}, 'Visit https://example.com/docs for docs.', {
+      url_allow_list: ['example.com'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
 
     expect(result.tripwireTriggered).toBe(false);
     expect(result.info?.allowed).toContain('https://example.com/docs');
@@ -308,21 +311,3202 @@ describe('urls guardrail', () => {
       'https://user:pass@secure.example.com',
       'javascript:alert(1)',
     ]);
-    expect((result.info?.blocked_reasons as string[])?.some((reason: string) => reason.includes('Blocked scheme: http'))).toBe(true);
-    expect((result.info?.blocked_reasons as string[])?.some((reason: string) => reason.includes('Contains userinfo'))).toBe(true);
+    expect(
+      (result.info?.blocked_reasons as string[])?.some((reason: string) =>
+        reason.includes('Blocked scheme: http')
+      )
+    ).toBe(true);
+    expect(
+      (result.info?.blocked_reasons as string[])?.some((reason: string) =>
+        reason.includes('Contains userinfo')
+      )
+    ).toBe(true);
   });
 
-  it('honours subdomain allowance settings', async () => {
+  it.each([
+    ['TAB', '\t'],
+    ['LF', '\n'],
+    ['CR', '\r'],
+  ])('blocks %s-obfuscated HTTP URLs before WHATWG normalization', async (_name, control) => {
+    const rawUrl = `htt${control}p://2130706433/internal/credentials`;
+    const parsed = new URL(rawUrl);
+
+    expect(parsed.protocol).toBe('http:');
+    expect(parsed.hostname).toBe('127.0.0.1');
+
+    const result = await urls({}, rawUrl, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toContain(rawUrl);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toContain(rawUrl);
+    expect(result.info?.blocked_reasons).toContain(
+      `${rawUrl}: Ambiguous URL containing ASCII control characters`
+    );
+  });
+
+  it('blocks controls at every internal position in recognized schemes', async () => {
+    const cases = [
+      ['http', '://example.com'],
+      ['https', '://example.com'],
+      ['ftp', '://example.com'],
+      ['ws', '://example.com'],
+      ['wss', '://example.com'],
+      ['file', ':///etc/passwd'],
+      ['data', ':text/plain,payload'],
+      ['javascript', ':alert(1)'],
+      ['vbscript', ':msgbox(1)'],
+      ['mailto', ':user@example.com'],
+    ] as const;
+
+    for (const control of ['\t', '\n', '\r']) {
+      for (const [scheme, suffix] of cases) {
+        for (let index = 1; index < scheme.length; index += 1) {
+          const rawUrl = `${scheme.slice(0, index)}${control}${scheme.slice(index)}${suffix}`;
+          const result = await urls({}, rawUrl, defaultUrlConfig);
+
+          expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+          expect(result.info?.blocked, JSON.stringify(rawUrl)).toContain(rawUrl);
+        }
+      }
+    }
+  });
+
+  it.each([
+    ['ws', 'ws://allowed.example/path'],
+    ['wss', 'wss://allowed.example/path'],
+    ['gopher', 'gopher://allowed.example/path'],
+  ])('allows an explicitly configured %s URL', async (scheme, rawUrl) => {
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set([scheme]),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('allows an explicitly configured mailto URL', async () => {
+    const rawUrl = 'mailto:user@example.com';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [],
+      allowed_schemes: new Set(['mailto']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['ws', 'ws://allowed.example/path'],
+    ['wss', 'wss://allowed.example/path'],
+    ['gopher', 'gopher://allowed.example/path'],
+    ['file', 'file:///etc/passwd'],
+    ['single-slash file', 'file:/etc/passwd'],
+    ['mailto', 'mailto:user@example.com'],
+    ['uppercase mailto', 'MAILTO:user@example.com'],
+  ])('blocks a normally spelled disallowed %s URL', async (_scheme, rawUrl) => {
+    const result = await urls({}, rawUrl, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['WebSocket scheme letters', 'w\ts://allowed.example/path', 'ws:'],
+    ['secure WebSocket scheme letters', 'ws\ts://allowed.example/path', 'wss:'],
+    ['file scheme letters', 'fi\tle:///etc/passwd', 'file:'],
+    ['mailto scheme letters', 'mai\tlto:user@allowed.example', 'mailto:'],
+    ['scheme letters', 'gop\ther://allowed.example/path', 'gopher:'],
+    ['scheme letters across a line', 'gop\nher://allowed.example/path', 'gopher:'],
+    ['authority separators', 'custom:\t//allowed.example/path', 'custom:'],
+    ['hostless scheme letters', 'cus\ttom:payload', 'custom:'],
+  ])(
+    'blocks a control-obfuscated generic URL across %s',
+    async (_name, rawUrl, expectedProtocol) => {
+      expect(new URL(rawUrl).protocol).toBe(expectedProtocol);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['Markdown emphasis after punctuation', 'See:_allowed.example/safe_', 'allowed.example/safe'],
+    ['nested wrappers after punctuation', 'See:(_allowed.example/safe_)', 'allowed.example/safe'],
+    ['an emphasized IP after punctuation', 'Host:_127.0.0.1/safe_', '127.0.0.1/safe'],
+    ['an emphasized IPv6 address', 'Host:_[::1]/safe_', '[::1]/safe'],
+    ['a parenthesized IPv6 address', 'Host:([::1]/safe)', '[::1]/safe'],
+  ])('detects a wrapped scheme-less URL in %s', async (_name, input, rawUrl) => {
+    const result = await urls({}, input, {
+      url_allow_list: [rawUrl],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('does not treat an emphasized domain inside a scheme-less path as a separate URL', async () => {
+    const rawUrl = 'allowed.example/_nested.example_';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [rawUrl],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('does not treat a parenthesized integer as a wrapped scheme-less URL', async () => {
+    const result = await urls({}, 'Version:(1)', {
+      url_allow_list: [],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('does not treat a function argument integer as a wrapped scheme-less URL', async () => {
+    const result = await urls({}, 'Version:fn(1)', {
+      url_allow_list: [],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('does not split a scheme-less URL at a query assignment', async () => {
+    const rawUrl = 'allowed.example/safe?next=other.example/path';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [rawUrl],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['an attribute', 'href="allowed.example/safe",next=x', ['allowed.example/safe']],
+    ['an unquoted HTML attribute', '<a href=allowed.example/safe>', ['allowed.example/safe']],
+    [
+      'multiple unquoted HTML attributes',
+      '<a href=allowed.example/safe data-src=other.example/path>',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    ['a CSS url function', 'url(allowed.example/safe)', ['allowed.example/safe']],
+    ['a quoted CSS url function', 'url("allowed.example/safe")', ['allowed.example/safe']],
+    [
+      'a CSS url function with inner whitespace',
+      'url( allowed.example/safe)',
+      ['allowed.example/safe'],
+    ],
+    [
+      'adjacent CSS url functions',
+      'url(allowed.example/safe),url(other.example/path)',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    ['a braced value', '{allowed.example/safe}', ['allowed.example/safe']],
+    [
+      'adjacent braced values',
+      '{allowed.example/safe}{other.example/path}',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    [
+      'comma-separated braced values',
+      '{allowed.example/safe},{other.example/path}',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    ['a pipe-delimited value', '|allowed.example/safe|', ['allowed.example/safe']],
+    [
+      'adjacent pipe-delimited values',
+      '|allowed.example/safe|other.example/path|',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    [
+      'pipe-delimited values with an empty column',
+      '|allowed.example/safe||other.example/path|',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    [
+      'comma-separated quoted values',
+      '"allowed.example/safe","other.example/path"',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    [
+      'comma-separated Markdown-emphasized values',
+      '*allowed.example/safe*,*other.example/path*',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    [
+      'adjacent underscore-emphasized values',
+      '_allowed.example/safe__other.example/path_',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    [
+      'adjacent inline-code values',
+      '`allowed.example/safe``other.example/path`',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    ['an angle-delimited value', '<allowed.example/safe>,next', ['allowed.example/safe']],
+    ['an inline-code value', '`allowed.example/safe`,next', ['allowed.example/safe']],
+    [
+      'a quoted URL with a scheme-like query value',
+      '"allowed.example/safe?next=data:value"',
+      ['allowed.example/safe?next=data:value'],
+    ],
+    [
+      'minified JSON fields',
+      '{"a":"allowed.example/safe","b":"other.example/path"}',
+      ['allowed.example/safe', 'other.example/path'],
+    ],
+    [
+      'single-quoted fields',
+      "{'a':'allowed.example/it's-safe','b':'other.example/path'}",
+      ["allowed.example/it's-safe", 'other.example/path'],
+    ],
+    [
+      'escaped quotes in a JSON value',
+      String.raw`{"url":"allowed.example/safe?label=\"value\"","other":"other.example/path"}`,
+      [String.raw`allowed.example/safe?label=\"value\"`, 'other.example/path'],
+    ],
+    [
+      'an even backslash run before a JSON delimiter',
+      String.raw`{"url":"allowed.example/safe?path=\\","other":"other.example/path"}`,
+      [String.raw`allowed.example/safe?path=\\`, 'other.example/path'],
+    ],
+  ])('separates wrapped scheme-less URLs in %s', async (_name, input, rawUrls) => {
+    const result = await urls({}, input, {
+      url_allow_list: rawUrls,
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual(rawUrls);
+    expect(result.info?.allowed).toEqual(rawUrls);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('keeps an ambiguous sibling wrapper fail closed', async () => {
+    const allowedUrl = 'allowed.example/safe';
+    const ambiguousUrl = '{allowed/.example/safe}';
+    const result = await urls({}, `{${allowedUrl}}${ambiguousUrl}`, {
+      url_allow_list: [allowedUrl, 'allowed'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([allowedUrl, ambiguousUrl]);
+    expect(result.info?.allowed).toEqual([allowedUrl]);
+    expect(result.info?.blocked).toEqual([ambiguousUrl]);
+  });
+
+  it.each([
+    ['an unscoped assignment terminator', 'src=allowed.example/safe>'],
+    ['a comparison before an assignment', '2 < 3 src=allowed.example/safe>'],
+    ['an excluded delimiter in an HTML attribute path', '<a href=allowed.example/safe^extra>'],
+  ])('keeps %s in the fail-closed candidate', async (_name, input) => {
+    const result = await urls({}, input, {
+      url_allow_list: ['allowed.example/safe'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual(result.info?.detected);
+  });
+
+  it.each([
+    ['javascript', 'javascript:"allowed.example/safe"'],
+    ['data', 'data:<allowed.example/safe>'],
+    ['vbscript', 'vbscript:`allowed.example/safe`'],
+    ['mailto', 'mailto:{user@allowed.example}'],
+  ])('blocks a %s URL whose payload starts with a delimiter', async (_name, rawUrl) => {
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example/safe'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['quote at the host start', 'gopher://"allowed.example/safe', '"allowed.example'],
+    ['quote within the host', 'custom://a"%2e/allowed.example/safe', 'a"%2e'],
+  ])('validates a generic authority URL with a %s', async (_name, rawUrl, expectedHost) => {
+    const parsedUrl = new URL(rawUrl);
+    expect(parsedUrl.hostname).toBe(expectedHost);
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set([parsedUrl.protocol.slice(0, -1)]),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('does not let an unrelated scheme-like prefix hide an obfuscated generic URL', async () => {
+    const rawUrl = 'gop\ther://allowed.example/path';
+    const input = `prefix:payload,${rawUrl}`;
+    const result = await urls({}, input, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['her']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(new URL(rawUrl).protocol).toBe('gopher:');
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['http without slashes', 'http:allowed.example/path', 'http:'],
+    ['http with one slash', 'http:/allowed.example/path', 'http:'],
+    ['http with a backslash', 'http:\\allowed.example/path', 'http:'],
+    ['ftp without slashes', 'ftp:allowed.example/path', 'ftp:'],
+    ['WebSocket with one slash', 'ws:/allowed.example/path', 'ws:'],
+    ['secure WebSocket with a backslash', 'wss:\\allowed.example/path', 'wss:'],
+    ['http with a slashless IPv6 host', 'http:[::1]/path', 'http:'],
+    ['WebSocket with a slashless IPv6 host', 'ws:[::1]/path', 'ws:'],
+  ])(
+    'blocks a disallowed WHATWG special scheme expressed as %s',
+    async (_name, rawUrl, expectedProtocol) => {
+      const parsedUrl = new URL(rawUrl);
+      expect(parsedUrl.protocol).toBe(expectedProtocol);
+      expect(['allowed.example', '[::1]']).toContain(parsedUrl.hostname);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example', '[::1]'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toContain(rawUrl);
+      expect(result.info?.allowed).not.toContain(rawUrl);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['a forward-slash path', 'https:intranet//allowed.example/safe', 'intranet'],
+    ['a backslash path', 'https:internal\\allowed.example/safe', 'internal'],
+    ['punctuation before slashes', 'https:;//allowed.example/safe', ';'],
+  ])(
+    'validates the outer host of a slashless special URL with %s',
+    async (_name, rawUrl, expectedHost) => {
+      expect(new URL(rawUrl).hostname).toBe(expectedHost);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toContain(rawUrl);
+      expect(result.info?.allowed).not.toContain(rawUrl);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    [
+      'query before NBSP',
+      'https:intranet?\u00a0//allowed.example/safe',
+      'intranet',
+      'https:intranet?',
+    ],
+    [
+      'fragment before OGHAM SPACE MARK',
+      'https:internal#\u1680//allowed.example/safe',
+      'internal',
+      'https:internal#',
+    ],
+  ])(
+    'validates a slashless special URL with a %s',
+    async (_name, rawUrl, expectedHost, expectedBlockedUrl) => {
+      expect(new URL(rawUrl).hostname).toBe(expectedHost);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toContain(expectedBlockedUrl);
+      expect(result.info?.allowed).not.toContain(expectedBlockedUrl);
+      expect(result.info?.blocked).toContain(expectedBlockedUrl);
+    }
+  );
+
+  it.each([
+    ['control before a path separator', 'allowed\r/.example:444/safe', 'allowed'],
+    ['control before a userinfo separator', 'allowed.\t@example:444/safe', 'example'],
+    ['control after a trailing host dot', 'allowed.\r/example:444/safe', 'allowed.'],
+    ['IDNA control before userinfo', '例え.\t@テスト/safe', 'xn--zckzah'],
+  ])(
+    'fails closed for an entire scheme-less URL with a %s',
+    async (_name, rawUrl, expectedHost) => {
+      expect(new URL(`http://${rawUrl}`).hostname).toBe(expectedHost);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['http://allowed.example:444/safe'],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['quote within a label', 'allowed".example:444/safe', 'allowed".example'],
+    ['brace after a separator', 'allowed.{example:444/safe', 'allowed.{example'],
+    ['quote before userinfo', 'allowed.example"@intranet:444/safe', 'intranet'],
+  ])('validates a scheme-less dotted authority with a %s', async (_name, rawUrl, expectedHost) => {
+    expect(new URL(`http://${rawUrl}`).hostname).toBe(expectedHost);
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['http://allowed.example:444/safe'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['quote', 'https:"%2e//allowed.example/safe', '".'],
+    ['opening brace', 'https:{%2e//allowed.example/safe', '{.'],
+    ['closing brace', 'https:}%2e//allowed.example/safe', '}.'],
+    ['backtick', 'https:`%2e//allowed.example/safe', '`.'],
+    ['label then quote', 'https:a"%2e//allowed.example/safe', 'a".'],
+    ['quote after one slash', 'https:/"%2e/allowed.example/safe', '".'],
+    ['quote at the host start', 'https://"allowed.example/safe', '"allowed.example'],
+  ])(
+    'validates a delayed special-scheme authority after a %s',
+    async (_name, rawUrl, expectedHost) => {
+      expect(new URL(rawUrl).hostname).toBe(expectedHost);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['path separator before a dotted suffix', 'allowed/.example/safe', 'allowed'],
+    ['encoded separator after a dot', 'allowed.%2eexample/safe', 'allowed..example'],
+    ['path separator within a label', 'allowed.e/xample/safe', 'allowed.e'],
+    ['IDNA path separator before a dotted suffix', '例え/.テスト/safe', 'xn--r8jz45g'],
+    ['IDNA encoded separator after a dot', '例え.%2eテスト/safe', 'xn--r8jz45g..xn--zckzah'],
+  ])(
+    'validates an entire strong scheme-less URL with a %s',
+    async (_name, rawUrl, expectedHost) => {
+      expect(new URL(`http://${rawUrl}`).hostname).toBe(expectedHost);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['http://allowed.example:444/safe'],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['path separator before a dotted suffix', 'allowed/.example/safe'],
+    ['encoded separator after a dot', 'allowed.%2eexample/safe'],
+    ['path separator within a label', 'allowed.e/xample/safe'],
+    ['IDNA path separator before a dotted suffix', '例え/.テスト/safe'],
+  ])('validates an embedded strong scheme-less URL with a %s', async (_name, rawUrl) => {
+    const result = await urls({}, `Visit ${rawUrl} today`, {
+      url_allow_list: [],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['parentheses', '(', ')'],
+    ['brackets', '[', ']'],
+    ['Markdown emphasis', '_', '_'],
+    ['nested Markdown emphasis', '**', '**'],
+    ['inline code', '`', '`'],
+    ['double quotes', '"', '"'],
+    ['angle brackets', '<', '>'],
+    ['an unmatched parenthesis', '(', ''],
+    ['unmatched Markdown emphasis', '_', ''],
+    ['nested leading punctuation', '([`', ''],
+    ['word-prefixed punctuation', 'x_', ''],
+  ])('validates a strong scheme-less URL wrapped in %s', async (_name, opening, closing) => {
+    const rawUrl = 'allowed/.example/safe';
+    const wrappedUrl = `${opening}${rawUrl}${closing}`;
+    const result = await urls({}, `Visit ${wrappedUrl} today`, {
+      url_allow_list: ['allowed'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([wrappedUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([wrappedUrl]);
+  });
+
+  it.each([
+    ['source path', 'src/package.test:123', 'package.test'],
+    ['documentation path', 'docs/readme.md:42/path', 'readme.md'],
+  ])('keeps a %s outside the disrupted URL heuristic', async (_name, input, dottedName) => {
+    for (const text of [input, `Visit ${input} today`]) {
+      const result = await urls({}, text, {
+        url_allow_list: [dottedName],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered, text).toBe(false);
+      expect(result.info?.detected, text).toEqual([dottedName]);
+      expect(result.info?.allowed, text).toEqual([dottedName]);
+      expect(result.info?.blocked, text).toEqual([]);
+    }
+  });
+
+  it.each([
+    ['parenthesized domain', '(', 'allowed.example/safe', ')', ''],
+    ['fullwidth parenthesized domain', '（', 'allowed.example/safe', '）', ''],
+    ['Markdown-emphasized domain', '_', 'allowed.example/safe', '_', ''],
+    ['nested Markdown-emphasized domain', '**', 'allowed.example/safe', '**', ''],
+    ['inline-code domain', '`', 'allowed.example/safe', '`', ''],
+    ['double-quoted domain', '"', 'allowed.example/safe', '"', ''],
+    ['angle-bracketed domain', '<', 'allowed.example/safe', '>', ''],
+    ['quoted domain followed by punctuation', "'", 'allowed.example/safe', "'", '.'],
+    ['fullwidth-quoted domain followed by punctuation', '「', 'allowed.example/safe', '」', '。'],
+    [
+      'parenthesized domain with a closing parenthesis in its path',
+      '(',
+      'allowed.example/safe)',
+      ')',
+      '',
+    ],
+    ['parenthesized IP address', '(', '127.0.0.1/safe', ')', ''],
+  ])(
+    'removes prose wrappers from a normal scheme-less %s',
+    async (_name, opening, rawUrl, closing, punctuation) => {
+      const result = await urls({}, `Visit ${opening}${rawUrl}${closing}${punctuation} today`, {
+        url_allow_list: [rawUrl],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([rawUrl]);
+      expect(result.info?.blocked).toEqual([]);
+    }
+  );
+
+  it.each([
+    ['Unicode IDNA', '例え.テスト/safe', '例え.テスト'],
+    ['punycode IDNA', 'xn--r8jz45g.xn--zckzah/safe', '例え.テスト'],
+    ['compatibility character', 'ℓ.com/safe', 'l.com'],
+    ['supplementary-plane IDNA', '😀.example/safe', '😀.example'],
+  ])('detects a normal scheme-less %s host', async (_name, rawUrl, allowedHost) => {
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [allowedHost],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('preserves the port, path, query, and fragment of a normal scheme-less URL', async () => {
+    const rawUrl = 'allowed.example:444/safe?token=allowed#frag';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [`http://${rawUrl}`],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each(['"', '`', '{', '}'])(
+    'validates a port-bearing scheme-less URL with an attached %s as one raw token',
+    async (prefix) => {
+      const allowedUrl = 'allowed.example:444/safe?token=allowed#frag';
+      const rawUrl = `${prefix}${allowedUrl}`;
+      const result = await urls({}, rawUrl, {
+        url_allow_list: [`http://${allowedUrl}`],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it('validates a numeric-leading final label when the scheme-less URL has a port', async () => {
+    const rawUrl = 'allowed.3example:444/safe?token=allowed#frag';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['http://allowed.example:444/safe?token=allowed#frag'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each(['allowed!.example', 'allowed._example', 'allowed.e_xample'])(
+    'validates non-DNS hostname punctuation in %s as part of the raw token',
+    async (hostname) => {
+      const rawUrl = `${hostname}/safe?token=allowed#frag`;
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['http://allowed.example/safe?token=allowed#frag'],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['inverted exclamation mark', '¡allowed.example/safe', 'xn--allowed-tha.example'],
+    ['middle dot', 'allowed·.example/safe', 'xn--allowed-1ma.example'],
+    ['Greek question mark', ';allowed.example/safe', ';allowed.example'],
+  ])(
+    'validates a scheme-less host containing an IDNA %s',
+    async (_name, rawUrl, normalizedHostname) => {
+      expect(new URL(`http://${rawUrl}`).hostname).toBe(normalizedHostname);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['an ASCII leading separator', '.allowed.example/safe', '.allowed.example'],
+    ['an IDNA leading separator', '。allowed.example/safe', '.allowed.example'],
+    ['consecutive IDNA separators', 'allowed。。example/safe', 'allowed..example'],
+    ['mixed consecutive separators', 'allowed.．example/safe', 'allowed..example'],
+    ['an encoded leading separator', '%2eallowed.example/safe', '.allowed.example'],
+    ['consecutive encoded separators', 'allowed%2e%2eexample/safe', 'allowed..example'],
+  ])('validates a scheme-less host containing %s', async (_name, rawUrl, normalizedHostname) => {
+    expect(new URL(`http://${rawUrl}`).hostname).toBe(normalizedHostname);
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['superscript digit', 'allowed.²example/safe', 'allowed.2example'],
+    ['subscript digit', 'allowed.₂example/safe', 'allowed.2example'],
+  ])(
+    'validates an IDNA final label beginning with a normalized %s',
+    async (_name, rawUrl, normalizedHostname) => {
+      expect(new URL(`http://${rawUrl}`).hostname).toBe(normalizedHostname);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['a normalized digit', 'allowed.\t²example/safe', 'allowed.2example'],
+    ['IDNA punctuation', 'allowed.\t¡example/safe', 'allowed.xn--example-tha'],
+    ['encoded separators', 'allowed%2\ne%2eexample/safe', 'allowed..example'],
+  ])(
+    'fails closed when a control changes %s in a scheme-less host',
+    async (_name, rawUrl, normalizedHostname) => {
+      expect(new URL(`http://${rawUrl}`).hostname).toBe(normalizedHostname);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    'localhost/internal',
+    '2130706433/internal',
+    '127.1/internal',
+    'foo_bar.example/internal',
+    '-allowed.example/internal',
+  ])('does not let unrelated text change extended-host detection of %s', async (rawUrl) => {
+    const config = {
+      url_allow_list: [],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    };
+    const baseline = await urls({}, rawUrl, config);
+    const contexts = [`日本語 ${rawUrl}`, `% note ${rawUrl}`, `xn-- note ${rawUrl}`];
+
+    for (const input of contexts) {
+      const withUnrelatedText = await urls({}, input, config);
+      expect(withUnrelatedText.info?.detected, input).toEqual(baseline.info?.detected);
+      expect(withUnrelatedText.tripwireTriggered, input).toBe(baseline.tripwireTriggered);
+    }
+  });
+
+  it.each([
+    ['percent escape', '127.1/internal%20path'],
+    ['punycode marker', '127.1/internal-xn--marker'],
+    ['Unicode', '127.1/日本語'],
+  ])('does not let %s in a path activate extended-host detection', async (_name, rawUrl) => {
+    const config = {
+      url_allow_list: [],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    };
+    const baseline = await urls({}, '127.1/internal', config);
+    const result = await urls({}, rawUrl, config);
+
+    expect(result.info?.detected).toEqual(baseline.info?.detected);
+    expect(result.tripwireTriggered).toBe(baseline.tripwireTriggered);
+  });
+
+  it('detects multiple normal scheme-less IDNA hosts independently', async () => {
+    const firstUrl = '例え.テスト/safe';
+    const secondUrl = 'ℓ.com/path';
+    const result = await urls({}, `Visit ${firstUrl} and ${secondUrl}`, {
+      url_allow_list: ['例え.テスト', 'l.com'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([firstUrl, secondUrl]);
+    expect(result.info?.allowed).toEqual([firstUrl, secondUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('does not duplicate a scheme-less IDNA host nested in an explicit URL', async () => {
+    const rawUrl = 'https://例え.テスト/safe';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['例え.テスト'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('validates a special-scheme path after WHATWG backslash normalization', async () => {
+    const rawUrl = 'https://allowed.example/safe\\..\\admin';
+    expect(new URL(rawUrl).pathname).toBe('/admin');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['https://allowed.example/safe'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([',', '.', ';', '!', ')'])(
+    'removes trailing %j prose punctuation from an authority URL',
+    async (punctuation) => {
+      const result = await urls({}, `Visit https://allowed.example${punctuation} now`, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.info?.detected).toEqual(['https://allowed.example']);
+      expect(result.info?.allowed).toEqual(['https://allowed.example']);
+      expect(result.info?.blocked).toEqual([]);
+    }
+  );
+
+  it.each(['。', '．', '｡'])(
+    'allows an authority followed by the %j Unicode dot separator',
+    async (separator) => {
+      const rawUrl = `https://allowed.example${separator}`;
+      expect(new URL(rawUrl).hostname).toBe('allowed.example.');
+
+      const result = await urls({}, `Visit ${rawUrl} now`, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([rawUrl]);
+      expect(result.info?.blocked).toEqual([]);
+    }
+  );
+
+  it('treats an allow-list hostname with a trailing dot as equivalent', async () => {
+    const rawUrl = 'https://allowed.example/path';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example.'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each(['-', '.', '+'])(
+    'detects a disallowed scheme after leading %j punctuation',
+    async (punctuation) => {
+      const rawUrl = 'http://allowed.example/path';
+      const result = await urls({}, `Visit ${punctuation}${rawUrl} now`, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each(['foo-http', 'foo.http', 'foo+http'])(
+    'does not split the allowed outer %s scheme',
+    async (scheme) => {
+      const rawUrl = `${scheme}://allowed.example/path`;
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set([scheme]),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([rawUrl]);
+      expect(result.info?.blocked).toEqual([]);
+    }
+  );
+
+  it.each([
+    ['Markdown emphasis', '_'],
+    ['Markdown strong emphasis', '**'],
+  ])('removes closing %s from a bare authority URL', async (_name, marker) => {
+    const rawUrl = 'https://allowed.example';
+    const result = await urls({}, `Visit ${marker}${rawUrl}${marker} now`, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['a JSON string', '{"url":"https://allowed.example"}', 'https'],
+    ['a quoted CSS url', 'url("https://allowed.example")', 'https'],
+    ['a generic URL in JSON', '{"url":"custom://allowed.example"}', 'custom'],
+  ])('removes paired wrappers from a bare authority URL in %s', async (_name, input, scheme) => {
+    const rawUrl = `${scheme}://allowed.example`;
+    const result = await urls({}, input, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set([scheme]),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('keeps bare authority URL ownership scoped to each JSON value', async () => {
+    const firstUrl = 'https://allowed.example';
+    const secondUrl = 'https://other.example';
+    const result = await urls({}, `{"first":"${firstUrl}","second":"${secondUrl}"}`, {
+      url_allow_list: ['allowed.example', 'other.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([firstUrl, secondUrl]);
+    expect(result.info?.allowed).toEqual([firstUrl, secondUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('keeps unpaired excluded authority delimiters fail closed', async () => {
+    const rawUrl = 'https://allowed.example"}';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['parenthesized path', '(', 'https://allowed.example/safe', ')'],
+    ['emphasized query', '_', 'https://allowed.example/safe?token=allowed', '_'],
+    ['strongly emphasized fragment', '**', 'https://allowed.example/safe#section', '**'],
+    ['nested wrappers', '(**', 'https://allowed.example/safe', '**)'],
+    ['parenthesized path before a period', '(', 'https://allowed.example/safe', ').'],
+    ['parenthesized path before a question mark', '(', 'https://allowed.example/safe', ')?'],
+    ['strongly emphasized path before a comma', '**', 'https://allowed.example/safe', '**,'],
+    ['single-quoted path', "'", 'https://allowed.example/safe', "'"],
+    ['struck-through path', '~~', 'https://allowed.example/safe', '~~'],
+    ['fullwidth parenthesized path', '（', 'https://allowed.example/safe', '）'],
+    ['corner-bracketed path', '「', 'https://allowed.example/safe', '」'],
+  ])('removes paired wrappers from a URL with a %s', async (_name, opening, rawUrl, closing) => {
+    const result = await urls({}, `Visit ${opening}${rawUrl}${closing} now`, {
+      url_allow_list: [rawUrl],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['path', 'https://allowed.example/safe,'],
+    ['query', 'https://allowed.example?token=allowed,'],
+    ['fragment', 'https://allowed.example#allowed,'],
+  ])('preserves trailing punctuation in a URL %s', async (_name, rawUrl) => {
+    const scheme = rawUrl.slice(0, rawUrl.indexOf(':'));
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [rawUrl],
+      allowed_schemes: new Set([scheme]),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['file path', 'file:///tmp/report,', new Set(['file'])],
+    ['generic empty-authority path', 'custom:///tmp/report,', new Set(['custom'])],
+  ])('does not clean punctuation from a %s', async (_name, rawUrl, allowedSchemes) => {
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [rawUrl],
+      allowed_schemes: allowedSchemes,
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['generic scheme', 'custom://allowed.example,', new Set(['custom'])],
+    ['scheme-relative URL', '//allowed.example,', new Set(['http', 'https'])],
+  ])('removes trailing prose punctuation from a %s', async (_name, rawUrl, allowedSchemes) => {
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: allowedSchemes,
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl.slice(0, -1)]);
+    expect(result.info?.allowed).toEqual([rawUrl.slice(0, -1)]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['query', 'https://allowed.example/safe?token=allowed\\]'],
+    ['fragment', 'https://allowed.example/safe#allowed\\]'],
+  ])('preserves trailing URL punctuation when validating an exact %s', async (_name, rawUrl) => {
+    const allowedUrl =
+      _name === 'query'
+        ? 'https://allowed.example/safe?token=allowed'
+        : 'https://allowed.example/safe#allowed';
+    const parsedUrl = new URL(rawUrl);
+    expect(_name === 'query' ? parsedUrl.search.slice(1) : parsedUrl.hash.slice(1)).not.toBe(
+      allowedUrl.split(_name === 'query' ? '?' : '#', 2)[1]
+    );
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [allowedUrl],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each(['^', '|', '{', '}', '`', '"', '<', '>', '[', ']'])(
+    'blocks userinfo bridged across the %j delimiter',
+    async (delimiter) => {
+      const rawUrl = `https://allowed.example${delimiter}@127.0.0.1/internal`;
+      const parsedUrl = new URL(rawUrl);
+      expect(parsedUrl.hostname).toBe('127.0.0.1');
+      expect(parsedUrl.username).not.toBe('');
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example', '127.0.0.1'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['slashless special scheme', 'http:allowed.example^@127.0.0.1/internal', 'http'],
+    ['generic authority scheme', 'gopher://allowed.example^@127.0.0.1/internal', 'gopher'],
+  ])('blocks delimiter-bridged userinfo in a %s', async (_name, rawUrl, scheme) => {
+    const parsedUrl = new URL(rawUrl);
+    expect(parsedUrl.hostname).toBe('127.0.0.1');
+    expect(parsedUrl.username).not.toBe('');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', '127.0.0.1'],
+      allowed_schemes: new Set([scheme]),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['forward slashes', '//'],
+    ['backslashes', '\\\\'],
+    ['mixed forward and backslashes', '/\\'],
+    ['mixed back and forward slashes', '\\/'],
+    ['three forward slashes', '///'],
+  ])('blocks userinfo in a scheme-relative URL with %s', async (_name, prefix) => {
+    const rawUrl = `${prefix}allowed.example@127.0.0.1/internal`;
+    const parsedUrl = new URL(rawUrl, 'https://base.example/root');
+    expect(parsedUrl.hostname).toBe('127.0.0.1');
+    expect(parsedUrl.username).toBe('allowed.example');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', '127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('does not confuse a scheme-relative host with the parser base hostname', async () => {
+    const rawUrl = '//allowed.example@url-filter.invalid/internal';
+    const parsedUrl = new URL(rawUrl, 'http://url-filter.invalid/');
+    expect(parsedUrl.hostname).toBe('url-filter.invalid');
+    expect(parsedUrl.username).toBe('allowed.example');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', 'url-filter.invalid'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['a numeric-leading final label', '//allowed.example@example.3com/internal', 'example.3com'],
+    ['a single-label host', '//allowed.example@intranet/internal', 'intranet'],
+  ])('blocks scheme-relative userinfo targeting %s', async (_name, rawUrl, hostname) => {
+    const parsedUrl = new URL(rawUrl, 'https://base.example/root');
+    expect(parsedUrl.hostname).toBe(hostname);
+    expect(parsedUrl.username).toBe('allowed.example');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', hostname],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['SPACE', ' '],
+    ['VT', '\v'],
+    ['FF', '\f'],
+    ['NBSP', '\u00a0'],
+    ['EM SPACE', '\u2003'],
+    ['LINE SEPARATOR', '\u2028'],
+  ])('blocks explicit userinfo bridged by %s', async (_name, whitespace) => {
+    const rawUrl = `https://allowed.example${whitespace}user@127.0.0.1/internal`;
+    const parsedUrl = new URL(rawUrl);
+    expect(parsedUrl.hostname).toBe('127.0.0.1');
+    expect(parsedUrl.username).not.toBe('');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', '127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['forward slashes', '//'],
+    ['backslashes', '\\\\'],
+  ])('blocks scheme-relative userinfo bridged by whitespace with %s', async (_name, prefix) => {
+    const rawUrl = `${prefix}allowed.example user@127.0.0.1/internal`;
+    const parsedUrl = new URL(rawUrl, 'https://base.example/root');
+    expect(parsedUrl.hostname).toBe('127.0.0.1');
+    expect(parsedUrl.username).not.toBe('');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', '127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('validates the parsed host even when whitespace-bridged userinfo is permitted', async () => {
+    const rawUrl = 'https://allowed.example user@127.0.0.1/internal';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('keeps an explicit URL separate from a following ordinary email address', async () => {
+    const sourceUrl = 'https://evil.example';
+    const bridgedUrl = `${sourceUrl} and email me@allowed.example`;
+    const result = await urls({}, `Visit ${bridgedUrl}`, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([sourceUrl, bridgedUrl]);
+    expect(result.info?.allowed).toEqual([bridgedUrl]);
+    expect(result.info?.blocked).toEqual([sourceUrl]);
+  });
+
+  it('assigns a whitespace bridge to the closest explicit URL', async () => {
+    const firstUrl = 'https://first.example/path';
+    const bridgedUrl = 'https://allowed.example user@127.0.0.1/internal';
+    const result = await urls({}, `${firstUrl} ${bridgedUrl}`, {
+      url_allow_list: ['first.example', 'allowed.example', '127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toHaveLength(2);
+    expect(result.info?.detected).toEqual(expect.arrayContaining([firstUrl, bridgedUrl]));
+    expect(result.info?.allowed).toEqual([firstUrl]);
+    expect(result.info?.blocked).toEqual([bridgedUrl]);
+  });
+
+  it.each([
+    ['SPACE', ' '],
+    ['VT', '\v'],
+    ['NBSP', '\u00a0'],
+    ['IDEOGRAPHIC SPACE', '\u3000'],
+  ])('blocks scheme-less userinfo bridged by %s', async (_name, whitespace) => {
+    const rawUrl = `allowed.example${whitespace}user@127.0.0.1/internal`;
+    const parsedUrl = new URL(`http://${rawUrl}`);
+    expect(parsedUrl.hostname).toBe('127.0.0.1');
+    expect(parsedUrl.username).not.toBe('');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', '127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('assigns a scheme-less whitespace bridge to the closest URL candidate', async () => {
+    const firstUrl = 'first.example/path';
+    const bridgedUrl = 'allowed.example user@127.0.0.1/internal';
+    const result = await urls({}, `${firstUrl} ${bridgedUrl}`, {
+      url_allow_list: ['first.example', 'allowed.example', '127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toHaveLength(2);
+    expect(result.info?.detected).toEqual(expect.arrayContaining([firstUrl, bridgedUrl]));
+    expect(result.info?.allowed).toEqual([firstUrl]);
+    expect(result.info?.blocked).toEqual([bridgedUrl]);
+  });
+
+  it('validates the scheme-less parsed host when whitespace-bridged userinfo is permitted', async () => {
+    const rawUrl = 'allowed.example user@127.0.0.1/internal';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['an explicit URL', 'https://allowed.example user@safe evil@intranet'],
+    ['a generic authority URL', 'gopher://allowed.example user@safe evil@intranet'],
+    ['a scheme-relative URL', '//allowed.example user@safe evil@intranet'],
+    ['a scheme-less URL', 'allowed.example user@safe evil@intranet'],
+  ])('validates the host after the last userinfo separator in %s', async (_name, rawUrl) => {
+    const parsedUrl = rawUrl.startsWith('//')
+      ? new URL(rawUrl, 'https://base.example/root')
+      : rawUrl.includes('://')
+        ? new URL(rawUrl)
+        : new URL(`http://${rawUrl}`);
+    expect(parsedUrl.hostname).toBe('intranet');
+    expect(parsedUrl.username).not.toBe('');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', 'safe'],
+      allowed_schemes: new Set(['https', 'gopher']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('keeps the original scheme while validating across an intermediate hostname', async () => {
+    const rawUrl = 'https://allowed.example user@safe.example evil @intranet';
+    expect(new URL(rawUrl).hostname).toBe('intranet');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', 'safe.example', 'http://intranet'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each(['/path', '?next=value', '#fragment'])(
+    'does not let an at-sign in %s hide a later scheme-less URL',
+    async (suffix) => {
+      const firstUrl = `https://allowed.example user@safe.example${suffix}`;
+      const secondUrl = 'other.example evil@intranet';
+      const input = `${firstUrl} ${secondUrl}`;
+      expect(new URL(input).hostname).toBe('safe.example');
+
+      const result = await urls({}, input, {
+        url_allow_list: ['allowed.example', 'safe.example', 'other.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([firstUrl, secondUrl]);
+      expect(result.info?.allowed).toEqual([firstUrl]);
+      expect(result.info?.blocked).toEqual([secondUrl]);
+    }
+  );
+
+  it('detects a scheme-relative single-label host when it has a path', async () => {
+    const rawUrl = '//intranet/internal';
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['intranet'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('blocks whitespace-bridged scheme-less userinfo after a numeric-leading label', async () => {
+    const rawUrl = 'example.3com user@127.0.0.1/internal';
+    const parsedUrl = new URL(`http://${rawUrl}`);
+    expect(parsedUrl.hostname).toBe('127.0.0.1');
+    expect(parsedUrl.username).not.toBe('');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['example.3com', '127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    '//allowed.example/safe://segment',
+    '//allowed.example/?next=https://other.example/path',
+  ])('does not treat :// inside a scheme-relative URL as its scheme prefix', async (rawUrl) => {
+    expect(new URL(rawUrl, 'https://base.example/root').hostname).toBe('allowed.example');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([rawUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['forward slashes separated by TAB', '/\t/'],
+    ['forward slashes separated by LF', '/\n/'],
+    ['backslashes separated by CR', '\\\r\\'],
+    ['mixed slashes separated by CRLF', '/\r\n\\'],
+  ])('blocks a control-obfuscated scheme-relative prefix with %s', async (_name, prefix) => {
+    const rawUrl = `${prefix}allowed.example/safe`;
+    const parsedUrl = new URL(rawUrl, 'https://base.example/root');
+    expect(parsedUrl.hostname).toBe('allowed.example');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+    expect(result.info?.blocked_reasons?.[0]).toContain(
+      'Ambiguous URL containing ASCII control characters'
+    );
+  });
+
+  it.each([
+    ['forward-slash scheme-relative URL', '//allowed.example/safe'],
+    ['backslash scheme-relative URL', '\\\\allowed.example\\safe'],
+    ['scheme-less URL with a path', 'allowed.example/safe'],
+  ])('keeps a %s separate from an explicit URL on the next line', async (_name, firstUrl) => {
+    const secondUrl = 'https://other.example/path';
+    const result = await urls({}, `${firstUrl}\n${secondUrl}`, {
+      url_allow_list: ['allowed.example', 'other.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toHaveLength(2);
+    expect(result.info?.detected).toEqual(expect.arrayContaining([firstUrl, secondUrl]));
+    expect(result.info?.allowed).toHaveLength(2);
+    expect(result.info?.allowed).toEqual(expect.arrayContaining([firstUrl, secondUrl]));
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['forward slashes', '//allowed.example/safe^/../admin'],
+    ['backslashes', '\\\\allowed.example\\safe^\\..\\admin'],
+  ])('validates delimiter-bridged paths in scheme-relative URLs with %s', async (_name, rawUrl) => {
+    expect(new URL(rawUrl, 'https://base.example/root').pathname).toBe('/admin');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['http://allowed.example/safe'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('does not treat an email address or a slash-prefixed word as a URL', async () => {
+    const result = await urls({}, 'Contact user@allowed.example or read //todo.', {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual(['allowed.example']);
+    expect(result.info?.allowed).toEqual(['allowed.example']);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['first.last+tag@allowed.example', 'allowed.example'],
+    ['first.last@allowed.example', 'allowed.example'],
+    ['first-last+tag@allowed.example', 'allowed.example'],
+    ['<first.last+tag@allowed.example>', 'allowed.example'],
+    ['用户.name@allowed.example', 'allowed.example'],
+    ['δοκιμή.user@allowed.example', 'allowed.example'],
+    ['u\u0308ser.name@allowed.example', 'allowed.example'],
+    ['\u{10400}.name@allowed.example', 'allowed.example'],
+    ['first.last+tag@allowed.example.', 'allowed.example'],
+    ['first.last+tag@allowed.example?', 'allowed.example'],
+    ['first.last+tag@例え.テスト', '例え.テスト'],
+    ['<first.last+tag@例え.テスト>', '例え.テスト'],
+    ['first.last+tag@例え。テスト', '例え。テスト'],
+    ['first.last+tag@例え．テスト', '例え．テスト'],
+    ['first.last+tag@例え｡テスト', '例え｡テスト'],
+    ['first.last+tag@例え.テスト。', '例え.テスト'],
+    ['first.last+tag@例え.テスト．', '例え.テスト'],
+    ['first.last+tag@例え.テスト｡', '例え.テスト'],
+    ['<first.last+tag@例え.テスト。>', '例え.テスト'],
+    ['(first.last+tag@例え.テスト．)', '例え.テスト'],
+  ])('does not treat the local part of %s as a URL', async (email, host) => {
+    const result = await urls({}, `Contact ${email} for help.`, {
+      url_allow_list: ['allowed.example', '例え.テスト'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([host]);
+    expect(result.info?.allowed).toEqual([host]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    'first.last+tag@allowed.example/path',
+    'first.last+tag@allowed.example:444',
+    'first.last+tag@allowed.example?q=1',
+    'first.last+tag@allowed.example#fragment',
+    '用户.name@allowed.example/path',
+    'first.last+tag@例え.テスト/path',
+    'first.last+tag@例え.テスト:444',
+  ])('keeps URL-like email syntax in userinfo validation for %s', async (rawUrl) => {
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example', '例え.テスト'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.blocked).toContain(rawUrl);
+  });
+
+  it.each([
+    ['IPv4', '127.0.0.1'],
+    ['decimal IPv4', '2130706433'],
+    ['hexadecimal IPv4', '0x7f000001'],
+    ['octal IPv4', '0177.0.0.1'],
+    ['short IPv4', '127.1'],
+    ['localhost', 'localhost'],
+    ['IPv6', '[::1]'],
+    ['numeric-leading final label', 'example.3com'],
+  ])('keeps the %s target in userinfo validation', async (_name, host) => {
+    const rawUrl = `first.last+tag@${host}`;
+    const parsedUrl = new URL(`http://${rawUrl}`);
+    expect(parsedUrl.username).not.toBe('');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [host, parsedUrl.hostname],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toContain(rawUrl);
+    expect(result.info?.blocked).toContain(rawUrl);
+    expect(result.info?.blocked_reasons).toEqual(
+      expect.arrayContaining([expect.stringContaining('Contains userinfo')])
+    );
+  });
+
+  it.each(['^', '|', '{', '}', '`', '"', '<', '>', '[', ']'])(
+    'validates a path bridged across the %j delimiter',
+    async (delimiter) => {
+      const rawUrl = `https://allowed.example/safe${delimiter}/../admin`;
+      expect(new URL(rawUrl).pathname).toBe('/admin');
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['https://allowed.example/safe'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it('blocks an obfuscated scheme after a Markdown underscore', async () => {
+    const rawUrl = 'htt\tp://allowed.com/path';
+    const result = await urls({}, `_${rawUrl}`, {
+      url_allow_list: ['allowed.com'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(new URL(rawUrl).protocol).toBe('http:');
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('blocks a dotted control-obfuscated scheme before an explicit URL', async () => {
+    const rawUrl = 'evil\nhttps://allowed.example/path';
+    const result = await urls({}, `Visit .${rawUrl}`, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(new URL(rawUrl).protocol).toBe('evilhttps:');
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('does not detect a URL scheme inside another scheme-like token', async () => {
+    const result = await urls({}, 'metadata:payload myjavascript:payload', defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('does not treat a scheme-like prose label as an empty hostless URL', async () => {
+    const result = await urls({}, 'data: value', defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('detects a hostless URL after a Markdown underscore', async () => {
+    const rawUrl = 'javascript:payload';
+    const result = await urls({}, `_${rawUrl}`, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['LF', '\n'],
+    ['CRLF', '\r\n'],
+    ['CR', '\r'],
+  ])('keeps explicit URLs on consecutive lines separate for %s', async (_name, lineBreak) => {
+    const firstUrl = 'https://allowed.example';
+    const secondUrl = 'https://other.example';
+    for (const indentation of ['', '\t', '\u00a0', '\u2003']) {
+      const result = await urls({}, `${firstUrl}${lineBreak}${indentation}${secondUrl}`, {
+        url_allow_list: ['allowed.example', 'other.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered, JSON.stringify(indentation)).toBe(false);
+      expect(result.info?.detected, JSON.stringify(indentation)).toEqual([firstUrl, secondUrl]);
+      expect(result.info?.allowed, JSON.stringify(indentation)).toEqual([firstUrl, secondUrl]);
+      expect(result.info?.blocked, JSON.stringify(indentation)).toEqual([]);
+    }
+  });
+
+  it.each(['\n', '\r\n', '\r'])(
+    'blocks a dotted prefix joined to an explicit authority URL across %j',
+    async (lineBreak) => {
+      const rawUrl = `evil.com${lineBreak}https://allowed.example/path`;
+      expect(new URL(rawUrl).protocol).toBe('evil.comhttps:');
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['evil.com', 'allowed.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each([
+    ['data', 'data:text/plain,a', 'data:text/plain,b'],
+    ['javascript', 'javascript:void(0)', 'javascript:void(1)'],
+    ['vbscript', 'vbscript:void(0)', 'vbscript:void(1)'],
+  ])('keeps consecutive %s URLs separate', async (scheme, firstUrl, secondUrl) => {
+    for (const lineBreak of ['\n', '\r\n', '\r']) {
+      for (const indentation of ['', '\t']) {
+        const input = `${firstUrl}${lineBreak}${indentation}${secondUrl}`;
+        const result = await urls({}, input, {
+          url_allow_list: [],
+          allowed_schemes: new Set([scheme]),
+          block_userinfo: true,
+          allow_subdomains: false,
+        });
+
+        expect(result.tripwireTriggered, JSON.stringify(input)).toBe(false);
+        expect(result.info?.detected, JSON.stringify(input)).toEqual([firstUrl, secondUrl]);
+        expect(result.info?.allowed, JSON.stringify(input)).toEqual([firstUrl, secondUrl]);
+        expect(result.info?.blocked, JSON.stringify(input)).toEqual([]);
+      }
+    }
+  });
+
+  it.each(['data', 'javascript', 'vbscript'])(
+    'blocks an authority URL followed by an allowed %s URL when control removal changes the authority',
+    async (scheme) => {
+      for (const lineBreak of ['\n', '\r\n', '\r']) {
+        const rawUrl = `https://allowed.co${lineBreak}${scheme}:443`;
+        const parsedUrl = new URL(rawUrl);
+
+        expect(parsedUrl.hostname).toBe(`allowed.co${scheme}`);
+
+        const result = await urls({}, rawUrl, {
+          url_allow_list: ['allowed.co'],
+          allowed_schemes: new Set(['https', scheme]),
+          block_userinfo: true,
+          allow_subdomains: false,
+        });
+
+        expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+        expect(result.info?.detected, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+        expect(result.info?.allowed, JSON.stringify(rawUrl)).toEqual([]);
+        expect(result.info?.blocked, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+      }
+    }
+  );
+
+  it.each([
+    ['domain suffix', 'allowed.co\nm/path', 'allowed.com'],
+    ['IPv4 segment', '127.0.0.\n1/path', '127.0.0.1'],
+    ['port digits', 'allowed.example:4\n43/path', 'allowed.example'],
+    ['query value', 'allowed.example?x=\n1', 'allowed.example'],
+  ])(
+    'blocks a control-bearing scheme-less URL across %s',
+    async (_name, rawUrl, expectedHostname) => {
+      const parsedUrl = new URL(`http://${rawUrl}`);
+
+      expect(parsedUrl.hostname).toBe(expectedHostname);
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.co', '127.0.0.1', 'allowed.example'],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it('keeps a trailing control outside a scheme-less URL candidate', async () => {
+    const result = await urls({}, 'allowed.example\n', {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual(['allowed.example']);
+    expect(result.info?.allowed).toEqual(['allowed.example']);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('blocks every parser-accepted internal control in scheme-less URL forms', async () => {
+    const baseUrls = [
+      'allowed.example/path?x=1#details',
+      'allowed.example?x=1#details',
+      'sub.allowed.example:444/path',
+      '127.0.0.1:8080/internal',
+      'www.allowed.example/path',
+    ];
+    const controls = ['\t', '\n', '\r', '\r\n', '\t\n', '\n\t', '\r\t'];
+    const config = {
+      url_allow_list: [
+        'allowed.example',
+        'sub.allowed.example',
+        '127.0.0.1',
+        'www.allowed.example',
+      ],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    };
+
+    for (const baseUrl of baseUrls) {
+      for (let position = 1; position < baseUrl.length; position += 1) {
+        for (const control of controls) {
+          const rawUrl = `${baseUrl.slice(0, position)}${control}${baseUrl.slice(position)}`;
+          try {
+            new URL(`http://${rawUrl}`);
+          } catch {
+            continue;
+          }
+
+          const result = await urls({}, `_${rawUrl}`, config);
+
+          expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+          expect(
+            result.info?.blocked?.some((candidate) => candidate.includes(rawUrl)),
+            JSON.stringify(rawUrl)
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('blocks every parser-accepted internal control in special scheme-less hosts', async () => {
+    const baseUrls = [
+      '2130706433/internal',
+      '0177.0.0.1/internal',
+      '017700000001/internal',
+      '0x7f000001/internal',
+      '2130706433./internal',
+      '0x7f000001./internal',
+      '0x7f.1/internal',
+      '127.1/internal',
+      '127.0.1/internal',
+      '0300.0250.0001.0001/internal',
+      '0x7f.0.0.1/internal',
+      '127.0000001/internal',
+      '127.0.0.1./internal',
+      '１２７。０。０。１/internal',
+      'example.xn--p1ai/internal',
+      '例え.テスト/internal',
+      'example。com/internal',
+      'example．com/internal',
+      'example｡com/internal',
+      '%65xample.com/internal',
+      'allowed%2eexample/internal',
+      'example%E3%80%82com/internal',
+      'example%EF%BC%8Ecom/internal',
+      'example%EF%BD%A1com/internal',
+      '127%2e0%2e0%2e1/internal',
+      '127%EF%BC%8E0%EF%BC%8E0%EF%BC%8E1/internal',
+      '%31%32%37%2e0%2e0%2e1/internal',
+      '%31%32%37。0%2e%30%E3%80%821/internal',
+      '%32%31%33%30%37%30%36%34%33%33/internal',
+      '0x7f%2e1/internal',
+      '0%78%37f｡%31/internal',
+      'localhost%2e/internal',
+      'localhost%EF%BC%8E/internal',
+      'local%68ost/internal',
+      '%6c%6f%63%61%6c%68%6f%73%74/internal',
+      'foo_bar.example/internal',
+      '[::1]/internal',
+      'localhost/internal',
+      'localhost./internal',
+      'ｌｏｃａｌｈｏｓｔ/internal',
+      'ℓocalhost/internal',
+      '@example.com/internal',
+      '@2130706433/internal',
+      '@localhost/internal',
+      '@[::1]/internal',
+      'user:pass@2130706433/internal',
+      'first@second@2130706433/internal',
+      'user:pass@0x7f000001/internal',
+      'user:pass@127.1/internal',
+      'first@second@example.com/internal',
+      'user:pass@_service.example/internal',
+      'user:pass@allowed%2eexample/internal',
+      'user:pass@example%E3%80%82com/internal',
+      'user:pass@local%68ost/internal',
+      'user:pass@例え.テスト/internal',
+      'user:pass@[::1]/internal',
+      'user:pass@localhost/internal',
+      'user:pass@ｌｏｃａｌｈｏｓｔ/internal',
+    ];
+    const controls = ['\t', '\n', '\r', '\r\n'];
+    const config = {
+      url_allow_list: [
+        '127.0.0.1',
+        '192.168.1.1',
+        'example.xn--p1ai',
+        '例え.テスト',
+        'example.com',
+        '[::1]',
+        'localhost',
+        'localhost.',
+      ],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    };
+
+    for (const baseUrl of baseUrls) {
+      for (let position = 1; position < baseUrl.length; position += 1) {
+        for (const control of controls) {
+          const rawUrl = `${baseUrl.slice(0, position)}${control}${baseUrl.slice(position)}`;
+          try {
+            new URL(`http://${rawUrl}`);
+          } catch {
+            continue;
+          }
+
+          for (const input of [
+            rawUrl,
+            `_${rawUrl}`,
+            `<${rawUrl}>`,
+            `[${rawUrl}]`,
+            `(${rawUrl})`,
+            `Visit ${rawUrl} today`,
+          ]) {
+            const result = await urls({}, input, config);
+
+            expect(result.tripwireTriggered, JSON.stringify(input)).toBe(true);
+            expect(
+              result.info?.blocked?.some((candidate) => candidate.includes(rawUrl)),
+              JSON.stringify(input)
+            ).toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  it('blocks control-bearing scheme-less URLs inside markup delimiters', async () => {
+    const baseUrl = 'allowed.example/path';
+    const config = {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    };
+
+    for (let position = 1; position < baseUrl.length; position += 1) {
+      for (const control of ['\t', '\n', '\r']) {
+        const rawUrl = `${baseUrl.slice(0, position)}${control}${baseUrl.slice(position)}`;
+        try {
+          new URL(`http://${rawUrl}`);
+        } catch {
+          continue;
+        }
+
+        for (const [opening, closing] of [
+          ['<', '>'],
+          ['[', ']'],
+        ]) {
+          const result = await urls({}, `${opening}${rawUrl}${closing}`, config);
+
+          expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+          expect(
+            result.info?.blocked?.some((candidate) => candidate.includes(rawUrl)),
+            JSON.stringify(rawUrl)
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it.each([
+    ['IPv4', '127\n.0.0.1/path'],
+    ['localhost', 'local\nhost/path'],
+    ['IPv6', '[::\n1]/path'],
+  ])('blocks a control-bearing scheme-less %s after punctuation', async (_name, rawUrl) => {
+    expect(new URL(`http://${rawUrl}`).hostname).toBeTruthy();
+
+    for (const punctuation of ['-', '.']) {
+      const result = await urls({}, `Visit ${punctuation}${rawUrl} today`, {
+        url_allow_list: ['127.0.0.1', 'localhost', '[::1]'],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: false,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered, punctuation).toBe(true);
+      expect(result.info?.detected, punctuation).toEqual([rawUrl]);
+      expect(result.info?.allowed, punctuation).toEqual([]);
+      expect(result.info?.blocked, punctuation).toEqual([rawUrl]);
+    }
+  });
+
+  it('blocks a whitespace-bridged scheme-less userinfo differential', async () => {
+    const rawUrl = 'allowed.example \n junk@2130706433';
+    const parsedUrl = new URL(`http://${rawUrl}`);
+
+    expect(parsedUrl.hostname).toBe('127.0.0.1');
+    expect(parsedUrl.username).not.toBe('');
+
+    const result = await urls({}, `Visit ${rawUrl} today`, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('blocks an entire scheme-less URL with control-bearing userinfo', async () => {
+    const rawUrl = 'user \n @2130706433';
+    const parsedUrl = new URL(`http://${rawUrl}`);
+
+    expect(parsedUrl.hostname).toBe('127.0.0.1');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['user'],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['forward slashes', '//'],
+    ['backslashes', '\\\\'],
+  ])('blocks control-bearing userinfo after scheme-relative %s', async (_name, prefix) => {
+    const schemelessUrl = 'us\ner@2130706433/internal';
+    const rawUrl = `${prefix}${schemelessUrl}`;
+
+    expect(new URL(rawUrl, 'https://example.com/base').hostname).toBe('127.0.0.1');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.blocked).toHaveLength(1);
+    expect(result.info?.blocked?.[0]).toContain(schemelessUrl);
+    expect(result.info?.blocked_reasons?.[0]).toContain(
+      'Ambiguous URL containing ASCII control characters'
+    );
+  });
+
+  it.each([
+    ['percent-encoded IPv4', '%31%32\n%37%2e0%2e0%2e1'],
+    ['percent-encoded localhost', 'local\n%68ost'],
+    ['fullwidth IPv4', '１２\n７。０。０。１'],
+    ['fullwidth localhost', 'ｌｏ\nｃａｌｈｏｓｔ'],
+    ['empty userinfo', '@\nlocalhost'],
+  ])('blocks an entire control-bearing %s without a URL suffix', async (_name, rawUrl) => {
+    const parsedUrl = new URL(`http://${rawUrl}`);
+
+    expect(['127.0.0.1', 'localhost']).toContain(parsedUrl.hostname);
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: [parsedUrl.hostname],
+      allowed_schemes: new Set(['http']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each(['\t', '\n', '\r'])(
+    'blocks control-bearing userinfo parser differentials for %j',
+    async (control) => {
+      const rawUrl = `http://allowed.example${control}@2130706433/internal/credentials`;
+      const parsed = new URL(rawUrl);
+
+      expect(parsed.username).toBe('allowed.example');
+      expect(parsed.hostname).toBe('127.0.0.1');
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['http']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each(['\t', '\n', '\r'])(
+    'blocks controls throughout hierarchical URL syntax for %j',
+    async (control) => {
+      const cases = [
+        {
+          rawUrl: `http:${control}//2130706433/internal`,
+          expectedUrl: 'http://127.0.0.1/internal',
+          config: defaultUrlConfig,
+        },
+        {
+          rawUrl: `http:/${control}/2130706433/internal`,
+          expectedUrl: 'http://127.0.0.1/internal',
+          config: defaultUrlConfig,
+        },
+        {
+          rawUrl: `http://${control}2130706433/internal`,
+          expectedUrl: 'http://127.0.0.1/internal',
+          config: defaultUrlConfig,
+        },
+        {
+          rawUrl: `https://allowed${control}.com/internal`,
+          expectedUrl: 'https://allowed.com/internal',
+          config: {
+            url_allow_list: ['allowed'],
+            allowed_schemes: new Set(['https']),
+            block_userinfo: true,
+            allow_subdomains: false,
+          },
+        },
+        {
+          rawUrl: `https://allowed.example/safe?role=user${control}&role=admin`,
+          expectedUrl: 'https://allowed.example/safe?role=user&role=admin',
+          config: {
+            url_allow_list: ['https://allowed.example/safe?role=user'],
+            allowed_schemes: new Set(['https']),
+            block_userinfo: true,
+            allow_subdomains: false,
+          },
+        },
+        {
+          rawUrl: `https://allowed.example/safe${control}evil`,
+          expectedUrl: 'https://allowed.example/safeevil',
+          config: {
+            url_allow_list: ['https://allowed.example/safe'],
+            allowed_schemes: new Set(['https']),
+            block_userinfo: true,
+            allow_subdomains: false,
+          },
+        },
+      ];
+
+      for (const { rawUrl, expectedUrl, config } of cases) {
+        expect(new URL(rawUrl).href).toBe(expectedUrl);
+
+        const result = await urls({}, rawUrl, config);
+
+        expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+        expect(result.info?.detected, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+        expect(result.info?.allowed, JSON.stringify(rawUrl)).toEqual([]);
+        expect(result.info?.blocked, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+      }
+    }
+  );
+
+  it('blocks parser-accepted controls at every internal URL position', async () => {
+    const baseUrls = [
+      'http://2130706433/internal/resource',
+      'https://allowed.example:444/path/to/resource?role=user#details',
+      'https://user:pass@allowed.example/internal/resource',
+      'https://[::1]:444/internal/resource',
+      'https://例え.テスト/internal/resource',
+      'https://allowed.example/path%2Fsegment',
+      'ftp://allowed.example:2121/internal/resource',
+      'data:text/plain,payload',
+      'javascript:payload',
+      'vbscript:payload',
+    ];
+
+    for (const baseUrl of baseUrls) {
+      for (const control of ['\t', '\n', '\r\n', '\r', '\t\n', '\n\t', '\r\t']) {
+        for (let index = 1; index < baseUrl.length; index += 1) {
+          const rawUrl = `${baseUrl.slice(0, index)}${control}${baseUrl.slice(index)}`;
+          let parsedUrl: URL;
+          try {
+            parsedUrl = new URL(rawUrl);
+          } catch {
+            continue;
+          }
+
+          const scheme = parsedUrl.protocol.replace(/:$/, '');
+          const result = await urls({}, `Visit ${rawUrl} today`, {
+            url_allow_list: parsedUrl.hostname ? [parsedUrl.hostname] : [],
+            allowed_schemes: new Set([scheme]),
+            block_userinfo: false,
+            allow_subdomains: false,
+          });
+
+          expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+          expect(result.info?.blocked, JSON.stringify(rawUrl)).toContain(rawUrl);
+        }
+      }
+    }
+  });
+
+  it.each(['data', 'javascript', 'vbscript'])(
+    'blocks trailing controls on a scheme-only %s URL',
+    async (scheme) => {
+      for (const control of ['\t', '\n', '\r\n', '\r', '\t\n', '\n\t', '\r\t']) {
+        const rawUrl = `${scheme}:${control}`;
+
+        expect(new URL(rawUrl).protocol).toBe(`${scheme}:`);
+
+        const result = await urls({}, rawUrl, defaultUrlConfig);
+
+        expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+        expect(result.info?.detected, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+        expect(result.info?.blocked, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+      }
+    }
+  );
+
+  it.each(['data', 'javascript', 'vbscript'])(
+    'validates a scheme-only %s URL before a consecutive explicit URL',
+    async (scheme) => {
+      for (const lineBreak of ['\n', '\r\n', '\r']) {
+        const secondUrl = 'https://allowed.example';
+        const input = `${scheme}:${lineBreak}${secondUrl}`;
+        const result = await urls({}, input, {
+          url_allow_list: ['allowed.example'],
+          allowed_schemes: new Set(['https']),
+          block_userinfo: true,
+          allow_subdomains: false,
+        });
+
+        expect(result.tripwireTriggered, JSON.stringify(input)).toBe(true);
+        expect(result.info?.detected, JSON.stringify(input)).toHaveLength(2);
+        expect(result.info?.detected, JSON.stringify(input)).toEqual(
+          expect.arrayContaining([scheme + ':', secondUrl])
+        );
+        expect(result.info?.allowed, JSON.stringify(input)).toEqual([secondUrl]);
+        expect(result.info?.blocked, JSON.stringify(input)).toEqual([scheme + ':']);
+      }
+    }
+  );
+
+  it.each(['\t', '\n', '\r'])(
+    'blocks controls in special URLs with zero to two authority separators for %j',
+    async (control) => {
+      for (const separators of ['', '/', '\\', '//', '/\\', '\\/', '\\\\']) {
+        const rawUrls = [
+          `htt${control}p:${separators}2130706433/internal`,
+          `http:${control}${separators}2130706433/internal`,
+        ];
+
+        for (const rawUrl of rawUrls) {
+          expect(new URL(rawUrl).href).toBe('http://127.0.0.1/internal');
+
+          const result = await urls({}, rawUrl, defaultUrlConfig);
+
+          expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+          expect(result.info?.detected, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+          expect(result.info?.allowed, JSON.stringify(rawUrl)).toEqual([]);
+          expect(result.info?.blocked, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+        }
+      }
+    }
+  );
+
+  it.each(['<', '>', '"', '|', '^', '`', '{', '}', '[', ']'])(
+    'blocks whole-input differentials before parser-accepted path character %j',
+    async (pathCharacter) => {
+      const rawUrl = `https://allowed.co\nm/path${pathCharacter}value`;
+
+      expect(new URL(rawUrl).hostname).toBe('allowed.com');
+
+      const result = await urls({}, rawUrl, {
+        url_allow_list: ['allowed.co'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each(['<', '>', '"', '|', '^', '`', '{', '}', '[', ']'])(
+    'blocks embedded differentials hidden behind candidate boundary character %j',
+    async (boundaryCharacter) => {
+      for (const control of ['\n', '\r']) {
+        const rawUrl = `https://allowed.example${control}${boundaryCharacter}junk@2130706433`;
+        const parsedUrl = new URL(rawUrl);
+
+        expect(parsedUrl.hostname).toBe('127.0.0.1');
+        expect(parsedUrl.username).not.toBe('');
+
+        const result = await urls({}, `Visit ${rawUrl} today`, {
+          url_allow_list: ['allowed.example'],
+          allowed_schemes: new Set(['https']),
+          block_userinfo: true,
+          allow_subdomains: false,
+        });
+
+        expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+        expect(result.info?.detected, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+        expect(result.info?.allowed, JSON.stringify(rawUrl)).toEqual([]);
+        expect(result.info?.blocked, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+      }
+    }
+  );
+
+  it.each([
+    ['SPACE', ' '],
+    ['VT', '\v'],
+    ['FF', '\f'],
+  ])('blocks embedded differentials hidden behind %s whitespace', async (_name, separator) => {
+    for (const control of ['\n', '\r']) {
+      for (const gap of [`${control}${separator}`, `${separator}${control}${separator}`]) {
+        const rawUrl = `https://allowed.example${gap}junk@2130706433`;
+        const parsedUrl = new URL(rawUrl);
+
+        expect(parsedUrl.hostname).toBe('127.0.0.1');
+        expect(parsedUrl.username).not.toBe('');
+
+        const result = await urls({}, `Visit ${rawUrl} today`, {
+          url_allow_list: ['allowed.example'],
+          allowed_schemes: new Set(['https']),
+          block_userinfo: true,
+          allow_subdomains: false,
+        });
+
+        expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+        expect(result.info?.detected, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+        expect(result.info?.allowed, JSON.stringify(rawUrl)).toEqual([]);
+        expect(result.info?.blocked, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+      }
+    }
+  });
+
+  it.each(['\n', '\r'])(
+    'blocks embedded authority differentials with later URL syntax for %j',
+    async (control) => {
+      for (const suffix of ['m', 'm/path', 'm\\path', 'm?query', 'm#fragment']) {
+        const rawUrl = `https://allowed.co${control}${suffix}`;
+
+        expect(new URL(rawUrl).hostname).not.toBe('allowed.co');
+
+        const result = await urls({}, `Visit ${rawUrl} today`, {
+          url_allow_list: ['allowed.co'],
+          allowed_schemes: new Set(['https']),
+          block_userinfo: true,
+          allow_subdomains: false,
+        });
+
+        expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+        expect(result.info?.detected, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+        expect(result.info?.allowed, JSON.stringify(rawUrl)).toEqual([]);
+        expect(result.info?.blocked, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+      }
+    }
+  );
+
+  it.each(['\n', '\r'])(
+    'blocks capitalized suffixes that change the hostname for %j',
+    async (control) => {
+      const rawUrl = `https://allowed.c${control}Om`;
+
+      expect(new URL(rawUrl).hostname).toBe('allowed.com');
+
+      const result = await urls({}, `Visit ${rawUrl} today`, {
+        url_allow_list: ['allowed.c'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each(['\n', '\r\n', '\r'])(
+    'blocks controls that change an explicit port for %j',
+    async (control) => {
+      const rawUrl = `https://127.0.0.1:4${control}43`;
+      const parsedUrl = new URL(rawUrl);
+
+      expect(parsedUrl.hostname).toBe('127.0.0.1');
+      expect(parsedUrl.port).toBe('');
+
+      const result = await urls({}, `Visit ${rawUrl} today`, {
+        url_allow_list: ['https://127.0.0.1:4'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each(['\n', '\r'])(
+    'blocks embedded email and mention suffixes that normalize to local hosts for %j',
+    async (control) => {
+      for (const suffix of ['user@2130706433', '@2130706433', 'user@127.0.0.1', 'user@localhost']) {
+        const rawUrl = `https://allowed.co${control}${suffix}`;
+        const normalizedHost = new URL(rawUrl).hostname;
+
+        expect(normalizedHost === 'localhost' || normalizedHost === '127.0.0.1').toBe(true);
+
+        const result = await urls({}, `Visit ${rawUrl} today`, {
+          url_allow_list: ['allowed.co'],
+          allowed_schemes: new Set(['https']),
+          block_userinfo: true,
+          allow_subdomains: false,
+        });
+
+        expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+        expect(result.info?.detected, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+        expect(result.info?.allowed, JSON.stringify(rawUrl)).toEqual([]);
+        expect(result.info?.blocked, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+      }
+    }
+  );
+
+  it.each(['\n', '\r'])(
+    'blocks embedded mention and email suffixes parsed as URL authority for %j',
+    async (control) => {
+      for (const suffix of ['@metadata', 'user@allowed.co']) {
+        const rawUrl = `https://allowed.co${control}${suffix}`;
+        const parsedUrl = new URL(rawUrl);
+
+        expect(parsedUrl.username).not.toBe('');
+
+        const result = await urls({}, `Visit ${rawUrl} today`, {
+          url_allow_list: ['allowed.co'],
+          allowed_schemes: new Set(['https']),
+          block_userinfo: true,
+          allow_subdomains: false,
+        });
+
+        expect(result.tripwireTriggered, JSON.stringify(rawUrl)).toBe(true);
+        expect(result.info?.detected, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+        expect(result.info?.allowed, JSON.stringify(rawUrl)).toEqual([]);
+        expect(result.info?.blocked, JSON.stringify(rawUrl)).toEqual([rawUrl]);
+      }
+    }
+  );
+
+  it.each(['\n', '\r'])(
+    'blocks embedded line breaks that change an allowlisted path for %j',
+    async (control) => {
+      const rawUrl = `https://allowed.example/safe${control}@metadata`;
+
+      expect(new URL(rawUrl).pathname).toBe('/safe@metadata');
+
+      const result = await urls({}, `Visit ${rawUrl} today`, {
+        url_allow_list: ['https://allowed.example/safe'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it('blocks a tab that extends an otherwise complete authority', async () => {
+    const rawUrl = 'https://allowed.example\tevil/internal';
+
+    expect(new URL(rawUrl).href).toBe('https://allowed.exampleevil/internal');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it.each([
+    ['LF', '\n'],
+    ['CRLF', '\r\n'],
+    ['CR', '\r'],
+  ])(
+    'fails closed when a bare %s can extend an otherwise complete authority',
+    async (_name, lineBreak) => {
+      const rawUrl = `https://example.com${lineBreak}Then`;
+
+      expect(new URL(rawUrl).hostname).toBe('example.comthen');
+
+      const result = await urls({}, `Visit ${rawUrl} continue`, {
+        url_allow_list: ['example.com'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.detected).toEqual([rawUrl]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([rawUrl]);
+    }
+  );
+
+  it.each(['\t', '\n', '\r\n', '\r'])(
+    'blocks a control immediately before closing prose punctuation for %j',
+    async (control) => {
+      const rawUrl = `https://allowed.example/path${control})`;
+
+      expect(new URL(rawUrl).pathname).toBe('/path)');
+
+      const result = await urls({}, `Visit ${rawUrl} today`, {
+        url_allow_list: ['allowed.example'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toHaveLength(1);
+      expect(result.info?.blocked[0]).toContain(control);
+    }
+  );
+
+  it('keeps multiline text when whitespace separates the URL from the next line', async () => {
     const result = await urls(
       {},
-      'Check https://sub.example.com and https://other.com',
+      'Visit https://example.com \nThen continue with the explanation.',
       {
         url_allow_list: ['example.com'],
         allowed_schemes: new Set(['https']),
-        allow_subdomains: true,
         block_userinfo: true,
+        allow_subdomains: false,
       }
     );
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual(['https://example.com']);
+    expect(result.info?.allowed).toEqual(['https://example.com']);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    'Version 1.2\nThen continue with the release notes.',
+    'The measured value is 3.14\r\nNext record follows.',
+  ])('does not treat multiline decimal prose as a scheme-less URL', async (input) => {
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('handles long percent-encoded prose without treating it as a URL', async () => {
+    const input = `Value ${'%31'.repeat(2_000)}\nThen decode it`;
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each([
+    ['ASCII dots', '.', false],
+    ['Unicode dots', '\u3002', false],
+    ['percent-encoded ASCII dots', '%2e', true],
+    ['percent-encoded Unicode dots', '%ef%bc%8e', true],
+  ])('handles a long separator-only token made of %s', async (_name, separator, detected) => {
+    const input = `${separator.repeat(24_000)}\n`;
+    const result = await urls({}, input, defaultUrlConfig);
+
+    const token = input.trim();
+    expect(result.tripwireTriggered).toBe(detected);
+    expect(result.info?.detected).toEqual(detected ? [token] : []);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual(detected ? [token] : []);
+  });
+
+  it('handles a long control-separated non-URL token without excessive backtracking', async () => {
+    const input = `${'a\t'.repeat(10_000)}payload`;
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('handles long scheme-character tokens without quadratic generic-scheme scanning', async () => {
+    for (const suffix of ['', ':', ':x', '://', '\t']) {
+      const input = `${'a.'.repeat(20_000)}${suffix}`;
+      const result = await urls({}, input, defaultUrlConfig);
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.info?.detected).toEqual([]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([]);
+    }
+
+    const genericUrl = `${'a.'.repeat(20_000)}://allowed.example/path`;
+    const result = await urls({}, genericUrl, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([genericUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([genericUrl]);
+
+    const bridgedInput = `${'a.'.repeat(20_000)} user@host`;
+    const bridgedResult = await urls({}, bridgedInput, defaultUrlConfig);
+
+    expect(bridgedResult.tripwireTriggered).toBe(true);
+    expect(bridgedResult.info?.detected).toHaveLength(1);
+    expect(bridgedResult.info?.allowed).toEqual([]);
+    expect(bridgedResult.info?.blocked).toHaveLength(1);
+  });
+
+  it('handles a long excluded-delimiter path without excessive backtracking', async () => {
+    const input = `https://allowed.example/${'^'.repeat(20_000)}tail`;
+    const result = await urls({}, input, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('handles a long unmatched paired-wrapper prefix without quadratic scanning', async () => {
+    for (const prefix of ['{'.repeat(20_000), '{('.repeat(10_000), '*'.repeat(20_000)]) {
+      const result = await urls({}, `${prefix}prose}`, defaultUrlConfig);
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.info?.detected).toEqual([]);
+      expect(result.info?.allowed).toEqual([]);
+      expect(result.info?.blocked).toEqual([]);
+    }
+  });
+
+  it('handles many separated unmatched paired wrappers without quadratic scanning', async () => {
+    const input = '(a'.repeat(200_000);
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('handles many paired openers with distant closers without quadratic scanning', async () => {
+    const input = `${'(a'.repeat(64_000)}${')'.repeat(64_000)}`;
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('handles many matched shared delimiters without quadratic scanning', async () => {
+    const input = '|a'.repeat(320_000);
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('handles many whitespace-separated URLs without quadratic bridge scanning', async () => {
+    const input = 'https://allowed.example '.repeat(2_000);
+    const result = await urls({}, input, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual(['https://allowed.example']);
+    expect(result.info?.allowed).toEqual(['https://allowed.example']);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('handles many assignment-like tokens without rescanning prior text', async () => {
+    const input = 'a=x.com '.repeat(32_000);
+    const result = await urls({}, input, {
+      url_allow_list: ['x.com'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual(['x.com']);
+    expect(result.info?.allowed).toEqual(['x.com']);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('handles many scheme-less bridge owners without quadratic scanning', async () => {
+    const bridgedUrl = 'allowed.example user@127.0.0.1/internal';
+    const input = `${'allowed.example '.repeat(2_000)}${bridgedUrl}`;
+    const result = await urls({}, input, {
+      url_allow_list: ['allowed.example', '127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toHaveLength(2);
+    expect(result.info?.detected).toEqual(expect.arrayContaining([bridgedUrl, 'allowed.example']));
+    expect(result.info?.allowed).toEqual(['allowed.example']);
+    expect(result.info?.blocked).toEqual([bridgedUrl]);
+  });
+
+  it('handles many userinfo separators without repeated prefix parsing', async () => {
+    const input = `https://allowed.example ${'user@safe '.repeat(2_000)}evil@intranet`;
+    const result = await urls({}, input, {
+      url_allow_list: ['allowed.example', 'safe'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([input]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([input]);
+  });
+
+  it('handles many ordinary IDN email addresses without repeated range scanning', async () => {
+    const input = '用户.name@例え.テスト '.repeat(2_000);
+    const result = await urls({}, input, {
+      url_allow_list: ['例え.テスト'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual(['例え.テスト']);
+    expect(result.info?.allowed).toEqual(['例え.テスト']);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('handles many special-host email candidates without repeated range scanning', async () => {
+    const rawUrl = 'first.last+tag@127.0.0.1';
+    const input = `${rawUrl} `.repeat(2_000);
+    const result = await urls({}, input, {
+      url_allow_list: ['127.0.0.1'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('handles an oversized invalid percent-encoded host without excessive backtracking', async () => {
+    const input = `${'%31'.repeat(20_000)}\n/path`;
+    expect(() => new URL(`http://${input}`)).toThrow();
+
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('blocks an oversized parser-accepted IDNA host without excessive backtracking', async () => {
+    const input = `${'ℓ'.repeat(20_000)}.com\n/path`;
+    expect(new URL(`http://${input}`).hostname).toMatch(/\.com$/);
+
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([input]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([input]);
+  });
+
+  it('handles many IDNA labels without quadratic excluded-delimiter scanning', async () => {
+    const rawUrl = `${'a。'.repeat(8_000)}a/path`;
+    const input = `${rawUrl} note ^ marker`;
+    expect(new URL(`http://${rawUrl}`).hostname).toContain('.');
+
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('handles long IDNA punctuation labels without repeated suffix scanning', async () => {
+    const hostname = `${'name·'.repeat(8_000)}example.test`;
+    const input = `${hostname}^note/path`;
+
+    const result = await urls({}, input, defaultUrlConfig);
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([hostname]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([hostname]);
+  });
+
+  it.each([
+    ['SPACE', ' '],
+    ['VT', '\v'],
+    ['FF', '\f'],
+    ['NBSP', '\u00a0'],
+    ['OGHAM SPACE MARK', '\u1680'],
+    ['EM SPACE', '\u2003'],
+    ['LINE SEPARATOR', '\u2028'],
+    ['PARAGRAPH SEPARATOR', '\u2029'],
+    ['NARROW NBSP', '\u202f'],
+    ['MEDIUM MATHEMATICAL SPACE', '\u205f'],
+    ['IDEOGRAPHIC SPACE', '\u3000'],
+    ['BOM', '\ufeff'],
+  ])('treats %s after a line break as a hard URL boundary', async (_name, separator) => {
+    for (const lineBreak of ['\n', '\r\n', '\r']) {
+      const input = `Visit https://example.com${lineBreak}${separator}Then continue`;
+      const result = await urls({}, input, {
+        url_allow_list: ['example.com'],
+        allowed_schemes: new Set(['https']),
+        block_userinfo: true,
+        allow_subdomains: false,
+      });
+
+      expect(result.tripwireTriggered, JSON.stringify(input)).toBe(false);
+      expect(result.info?.detected, JSON.stringify(input)).toEqual(['https://example.com']);
+      expect(result.info?.allowed, JSON.stringify(input)).toEqual(['https://example.com']);
+      expect(result.info?.blocked, JSON.stringify(input)).toEqual([]);
+    }
+  });
+
+  it.each([
+    ['an at-mention', 'Visit https://example.com \n@example can help', ['example.com']],
+    [
+      'an email address',
+      'Visit https://example.com \nuser@example.org can help',
+      ['example.com', 'example.org'],
+    ],
+  ])('blocks whitespace-separated %s when WHATWG can join it', async (_name, text, allowList) => {
+    const result = await urls({}, text, {
+      url_allow_list: allowList,
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toHaveLength(1);
+  });
+
+  it('bridges to the first at-sign after the control', async () => {
+    const rawUrl = 'https://allowed.example user@example.com \n junk@2130706433';
+    const parsedUrl = new URL(rawUrl);
+
+    expect(parsedUrl.hostname).toBe('127.0.0.1');
+    expect(parsedUrl.username).not.toBe('');
+
+    const result = await urls({}, `Visit ${rawUrl} today`, {
+      url_allow_list: ['allowed.example', 'example.com'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+    expect(result.info?.blocked_reasons).toContain(
+      `${rawUrl}: Ambiguous URL containing ASCII control characters`
+    );
+  });
+
+  it.each(['\n', '\r'])('blocks scheme-like userinfo after whitespace for %j', async (control) => {
+    const rawUrl = `https://allowed.example${control} https:foo@2130706433`;
+
+    expect(new URL(rawUrl).href).toBe('https://allowed.example%20https:foo@127.0.0.1/');
+
+    const result = await urls({}, `Visit ${rawUrl} today`, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('uses the closest scheme before a control as the userinfo bridge', async () => {
+    const rawUrl = 'https://allowed.example\n https:foo@2130706433';
+    const input = `Items: ${'data:x '.repeat(256)}${rawUrl} today`;
+
+    const result = await urls({}, input, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['data', 'https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('preserves an explicit authority boundary after a slashless scheme token', async () => {
+    const firstUrl = 'https://allowed.example';
+    const secondUrl = 'https://user@other.example';
+    const input = `${firstUrl}\n https:note ${secondUrl}`;
+
+    const result = await urls({}, input, {
+      url_allow_list: ['allowed.example', 'other.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([firstUrl, secondUrl]);
+    expect(result.info?.allowed).toEqual([firstUrl, secondUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it('keeps an explicit authority URL after a line break separate', async () => {
+    const firstUrl = 'https://allowed.example';
+    const secondUrl = 'https://user@other.example';
+    const result = await urls({}, `Visit ${firstUrl}\n ${secondUrl} today`, {
+      url_allow_list: ['allowed.example', 'other.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: false,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.detected).toEqual([firstUrl, secondUrl]);
+    expect(result.info?.allowed).toEqual([firstUrl, secondUrl]);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each(['\n', '\r'])('blocks a whole-input userinfo differential after %j', async (control) => {
+    const rawUrl = `https://allowed.example${control}@2130706433`;
+
+    expect(new URL(rawUrl).href).toBe('https://allowed.example@127.0.0.1/');
+
+    const result = await urls({}, rawUrl, {
+      url_allow_list: ['allowed.example'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toEqual([rawUrl]);
+    expect(result.info?.allowed).toEqual([]);
+    expect(result.info?.blocked).toEqual([rawUrl]);
+  });
+
+  it('classifies normal and ambiguous URLs independently', async () => {
+    const ambiguousUrl = 'htt\tp://2130706433/internal/credentials';
+    const result = await urls({}, `Visit https://example.com and never fetch ${ambiguousUrl}`, {
+      url_allow_list: ['example.com'],
+      allowed_schemes: new Set(['https']),
+      block_userinfo: true,
+      allow_subdomains: false,
+    });
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.allowed).toEqual(['https://example.com']);
+    expect(result.info?.blocked).toEqual([ambiguousUrl]);
+  });
+
+  it('honours subdomain allowance settings', async () => {
+    const result = await urls({}, 'Check https://sub.example.com and https://other.com', {
+      url_allow_list: ['example.com'],
+      allowed_schemes: new Set(['https']),
+      allow_subdomains: true,
+      block_userinfo: true,
+    });
 
     expect(result.info?.allowed).toContain('https://sub.example.com');
     expect(result.info?.blocked).toContain('https://other.com');
@@ -336,22 +3520,15 @@ describe('urls guardrail', () => {
       'https://api.example.com/v2',
     ].join(' ');
 
-    const result = await urls(
-      {},
-      text,
-      {
-        url_allow_list: ['https://suntropy.es', 'https://api.example.com/v1'],
-        allowed_schemes: new Set(['https']),
-        allow_subdomains: false,
-        block_userinfo: true,
-      }
-    );
+    const result = await urls({}, text, {
+      url_allow_list: ['https://suntropy.es', 'https://api.example.com/v1'],
+      allowed_schemes: new Set(['https']),
+      allow_subdomains: false,
+      block_userinfo: true,
+    });
 
     expect(result.info?.allowed).toEqual(
-      expect.arrayContaining([
-        'https://suntropy.es',
-        'https://api.example.com/v1/tools?id=2',
-      ])
+      expect.arrayContaining(['https://suntropy.es', 'https://api.example.com/v1/tools?id=2'])
     );
     expect(result.info?.blocked).toContain('https://api.example.com/v2');
   });
@@ -364,44 +3541,30 @@ describe('urls guardrail', () => {
       'https://example.com/api-v2',
     ].join(' ');
 
-    const result = await urls(
-      {},
-      text,
-      {
-        url_allow_list: ['https://example.com/api'],
-        allowed_schemes: new Set(['https']),
-        allow_subdomains: false,
-        block_userinfo: true,
-      }
-    );
+    const result = await urls({}, text, {
+      url_allow_list: ['https://example.com/api'],
+      allowed_schemes: new Set(['https']),
+      allow_subdomains: false,
+      block_userinfo: true,
+    });
 
     expect(result.info?.allowed).toEqual(
-      expect.arrayContaining([
-        'https://example.com/api',
-        'https://example.com/api/users',
-      ])
+      expect.arrayContaining(['https://example.com/api', 'https://example.com/api/users'])
     );
     expect(result.info?.blocked).toEqual(
-      expect.arrayContaining([
-        'https://example.com/api2',
-        'https://example.com/api-v2',
-      ])
+      expect.arrayContaining(['https://example.com/api2', 'https://example.com/api-v2'])
     );
   });
 
   it('matches scheme-less allow list entries across configured schemes', async () => {
     const text = ['https://example.com', 'http://example.com'].join(' ');
 
-    const result = await urls(
-      {},
-      text,
-      {
-        url_allow_list: ['example.com'],
-        allowed_schemes: new Set(['https', 'http']),
-        allow_subdomains: false,
-        block_userinfo: true,
-      }
-    );
+    const result = await urls({}, text, {
+      url_allow_list: ['example.com'],
+      allowed_schemes: new Set(['https', 'http']),
+      allow_subdomains: false,
+      block_userinfo: true,
+    });
 
     expect(result.info?.allowed).toEqual(
       expect.arrayContaining(['https://example.com', 'http://example.com'])
@@ -412,16 +3575,12 @@ describe('urls guardrail', () => {
   it('enforces explicit scheme matches when allow list entries include schemes', async () => {
     const text = ['https://bank.example.com', 'http://bank.example.com'].join(' ');
 
-    const result = await urls(
-      {},
-      text,
-      {
-        url_allow_list: ['https://bank.example.com'],
-        allowed_schemes: new Set(['https', 'http']),
-        allow_subdomains: false,
-        block_userinfo: true,
-      }
-    );
+    const result = await urls({}, text, {
+      url_allow_list: ['https://bank.example.com'],
+      allowed_schemes: new Set(['https', 'http']),
+      allow_subdomains: false,
+      block_userinfo: true,
+    });
 
     expect(result.info?.allowed).toEqual(expect.arrayContaining(['https://bank.example.com']));
     expect(result.info?.blocked).toContain('http://bank.example.com');
@@ -437,16 +3596,17 @@ describe('urls guardrail', () => {
       'https://api.internal.com:9000',
     ].join(' ');
 
-    const result = await urls(
-      {},
-      text,
-      {
-        url_allow_list: ['10.0.0.0/8', '192.168.1.0/24', 'https://example.com:8443', 'api.internal.com'],
-        allowed_schemes: new Set(['https']),
-        allow_subdomains: false,
-        block_userinfo: true,
-      }
-    );
+    const result = await urls({}, text, {
+      url_allow_list: [
+        '10.0.0.0/8',
+        '192.168.1.0/24',
+        'https://example.com:8443',
+        'api.internal.com',
+      ],
+      allowed_schemes: new Set(['https']),
+      allow_subdomains: false,
+      block_userinfo: true,
+    });
 
     expect(result.info?.allowed).toEqual(
       expect.arrayContaining([
@@ -469,19 +3629,12 @@ describe('urls guardrail', () => {
       'https://example.com/docs#outro',
     ].join(' ');
 
-    const result = await urls(
-      {},
-      text,
-      {
-        url_allow_list: [
-          'https://example.com/search?q=test',
-          'https://example.com/docs#intro',
-        ],
-        allowed_schemes: new Set(['https']),
-        allow_subdomains: false,
-        block_userinfo: true,
-      }
-    );
+    const result = await urls({}, text, {
+      url_allow_list: ['https://example.com/search?q=test', 'https://example.com/docs#intro'],
+      allowed_schemes: new Set(['https']),
+      allow_subdomains: false,
+      block_userinfo: true,
+    });
 
     expect(result.info?.allowed).toEqual(
       expect.arrayContaining([
@@ -498,16 +3651,12 @@ describe('urls guardrail', () => {
   });
 
   it('blocks URLs containing only a password in userinfo when configured', async () => {
-    const result = await urls(
-      {},
-      'https://:secret@example.com',
-      {
-        url_allow_list: ['example.com'],
-        allowed_schemes: new Set(['https']),
-        allow_subdomains: false,
-        block_userinfo: true,
-      }
-    );
+    const result = await urls({}, 'https://:secret@example.com', {
+      url_allow_list: ['example.com'],
+      allowed_schemes: new Set(['https']),
+      allow_subdomains: false,
+      block_userinfo: true,
+    });
 
     expect(result.info?.blocked).toContain('https://:secret@example.com');
     expect(
@@ -522,16 +3671,12 @@ describe('urls guardrail', () => {
       'https://example.com:-1',
     ].join(' ');
 
-    const result = await urls(
-      {},
-      text,
-      {
-        url_allow_list: ['example.com'],
-        allowed_schemes: new Set(['https']),
-        allow_subdomains: false,
-        block_userinfo: true,
-      }
-    );
+    const result = await urls({}, text, {
+      url_allow_list: ['example.com'],
+      allowed_schemes: new Set(['https']),
+      allow_subdomains: false,
+      block_userinfo: true,
+    });
 
     expect(result.tripwireTriggered).toBe(true);
     expect(result.info?.blocked).toHaveLength(3);
@@ -547,22 +3692,15 @@ describe('urls guardrail', () => {
       'https://example.com/other',
     ].join(' ');
 
-    const result = await urls(
-      {},
-      text,
-      {
-        url_allow_list: ['https://example.com/api/'],
-        allowed_schemes: new Set(['https']),
-        allow_subdomains: false,
-        block_userinfo: true,
-      }
-    );
+    const result = await urls({}, text, {
+      url_allow_list: ['https://example.com/api/'],
+      allowed_schemes: new Set(['https']),
+      allow_subdomains: false,
+      block_userinfo: true,
+    });
 
     expect(result.info?.allowed).toEqual(
-      expect.arrayContaining([
-        'https://example.com/api/users',
-        'https://example.com/api/v2/data',
-      ])
+      expect.arrayContaining(['https://example.com/api/users', 'https://example.com/api/v2/data'])
     );
     expect(result.info?.blocked).toContain('https://example.com/other');
   });
@@ -600,7 +3738,7 @@ describe('urls guardrail', () => {
       allow_subdomains: false,
       block_userinfo: true,
     };
-    
+
     const text = 'Visit help-suntropy.es and help.suntropy.es';
     const result = await urls({}, text, config);
 
@@ -703,11 +3841,9 @@ describe('urls guardrail', () => {
 
 describe('competitors guardrail', () => {
   it('reuses keywords check and annotates guardrail name', () => {
-    const result = competitorsCheck(
-      {},
-      'We prefer Acme Corp over others.',
-      { keywords: ['acme corp'] }
-    ) as GuardrailResult;
+    const result = competitorsCheck({}, 'We prefer Acme Corp over others.', {
+      keywords: ['acme corp'],
+    }) as GuardrailResult;
 
     expect(result.tripwireTriggered).toBe(true);
     expect(result.info?.guardrail_name).toBe('Competitors');

--- a/src/checks/urls.ts
+++ b/src/checks/urls.ts
@@ -12,10 +12,1677 @@ import { defaultSpecRegistry } from '../registry';
 const DEFAULT_PORTS: Record<string, number> = {
   http: 80,
   https: 443,
+  ws: 80,
+  wss: 443,
 };
 
-const SCHEME_PREFIX_RE = /^[a-z][a-z0-9+.-]*:\/\//;
+const SCHEME_PREFIX_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 const HOSTLESS_SCHEMES = new Set(['data', 'javascript', 'vbscript', 'mailto']);
+const ASCII_URL_CONTROL_RE = /[\t\n\r]/;
+// WHATWG removes TAB/LF/CR inside a URL. Every other ECMAScript whitespace
+// character remains a token boundary and must not be absorbed as URL content.
+const NON_CONTROL_WHITESPACE_CHARACTER_CLASS =
+  '\\x0b\\x0c\\x20\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff';
+const NON_CONTROL_WHITESPACE_RE = new RegExp(`[${NON_CONTROL_WHITESPACE_CHARACTER_CLASS}]`, 'u');
+const URL_WHITESPACE_RE = /\s/u;
+const TRAILING_URL_CONTROL_RE = /[\t\n\r]+$/;
+const AMBIGUOUS_URL_REASON = 'Ambiguous URL containing ASCII control characters';
+
+const AUTHORITY_SCHEMES = ['http', 'https', 'ftp', 'ws', 'wss', 'file'];
+const DETECTED_HOSTLESS_SCHEMES = ['data', 'javascript', 'vbscript', 'mailto'];
+const DETECTED_SCHEMES = new Set([...AUTHORITY_SCHEMES, ...DETECTED_HOSTLESS_SCHEMES]);
+const DETECTED_SCHEME_IN_TOKEN_RE = new RegExp(
+  `(?:^|[^a-z0-9])(?:${[...DETECTED_SCHEMES].join('|')}):`,
+  'i'
+);
+const DETECTED_HOSTLESS_SCHEME_ONLY_RE = new RegExp(
+  `^(?:${DETECTED_HOSTLESS_SCHEMES.join('|')}):$`,
+  'i'
+);
+const CONTROL_GAP_PATTERN = '[\\t\\n\\r]*';
+const withOptionalControls = (scheme: string): string => scheme.split('').join(CONTROL_GAP_PATTERN);
+const CONTROL_TOLERANT_AUTHORITY_PREFIXES = AUTHORITY_SCHEMES.map(
+  (scheme) => `${withOptionalControls(scheme)}${CONTROL_GAP_PATTERN}:`
+);
+const CONTROL_TOLERANT_HOSTLESS_PREFIXES = DETECTED_HOSTLESS_SCHEMES.map(
+  (scheme) => `${withOptionalControls(scheme)}${CONTROL_GAP_PATTERN}:`
+);
+const GENERIC_SCHEME_PATTERN = '[a-z][a-z0-9+.-]*';
+const CONTROL_TOLERANT_GENERIC_AUTHORITY_PREFIX =
+  `${GENERIC_SCHEME_PATTERN}${CONTROL_GAP_PATTERN}:${CONTROL_GAP_PATTERN}` +
+  `\\/${CONTROL_GAP_PATTERN}\\/`;
+const EXPLICIT_AUTHORITY_URL_PREFIX_PATTERN = `${GENERIC_SCHEME_PATTERN}:\\/\\/`;
+const EXPLICIT_HOSTLESS_URL_PREFIX_PATTERN = `(?:${DETECTED_HOSTLESS_SCHEMES.join('|')}):`;
+const EXPLICIT_URL_PREFIX_PATTERN = `(?:${EXPLICIT_AUTHORITY_URL_PREFIX_PATTERN}|${EXPLICIT_HOSTLESS_URL_PREFIX_PATTERN})`;
+const WHITESPACE_BRIDGE_EXPLICIT_OWNER_RE = new RegExp(
+  `(?<![a-z0-9])(?:(?:${AUTHORITY_SCHEMES.join('|')}):|` + `${GENERIC_SCHEME_PATTERN}://)[^\\s@]*`,
+  'gi'
+);
+const WHITESPACE_BRIDGE_SCHEME_RELATIVE_OWNER_RE = /(?<![:/\\])[/\\]{2,}[^\s@]*/g;
+const SCHEME_RELATIVE_BASE_URL = 'http://url-filter.invalid/';
+const SCHEME_RELATIVE_URL_RE = /(?<![a-z0-9+.:/\\-])[/\\]{2,}[^\s]+/gi;
+const hasExplicitAuthorityScheme = (value: string): boolean => SCHEME_PREFIX_RE.test(value);
+const EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_PATTERN = `(?:\\r\\n?|\\n)\\t*(?=${EXPLICIT_AUTHORITY_URL_PREFIX_PATTERN})`;
+const EXPLICIT_URL_LINE_BOUNDARY_PATTERN = `(?:\\r\\n?|\\n)\\t*(?=${EXPLICIT_URL_PREFIX_PATTERN})`;
+const EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_RE = new RegExp(
+  EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_PATTERN,
+  'i'
+);
+const EXPLICIT_URL_LINE_BOUNDARY_RE = new RegExp(EXPLICIT_URL_LINE_BOUNDARY_PATTERN, 'i');
+// WHATWG parsing removes TAB/LF/CR throughout a URL before interpreting it.
+// Authority URLs only split before another authority URL: a following hostless
+// scheme can become part of the authority after control removal. Hostless URLs
+// can split before any explicit URL because their payload has no authority.
+// Any control left inside the resulting candidate fails closed.
+const CONTROL_TOLERANT_URL_CANDIDATE_RE = new RegExp(
+  `(?<![a-z0-9])(?:` +
+    `(?:${CONTROL_TOLERANT_GENERIC_AUTHORITY_PREFIX})` +
+    `(?:(?!${EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_PATTERN})[^${NON_CONTROL_WHITESPACE_CHARACTER_CLASS}])+|` +
+    `(?:${CONTROL_TOLERANT_AUTHORITY_PREFIXES.join(
+      '|'
+    )})(?:(?!${EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_PATTERN})[^${NON_CONTROL_WHITESPACE_CHARACTER_CLASS}])+|` +
+    `(?:${CONTROL_TOLERANT_HOSTLESS_PREFIXES.join(
+      '|'
+    )})(?:(?!${EXPLICIT_URL_LINE_BOUNDARY_PATTERN})[^${NON_CONTROL_WHITESPACE_CHARACTER_CLASS}])+` +
+    `)`,
+  'gi'
+);
+const CONTROL_BEARING_TOKEN_RE = new RegExp(
+  `[^${NON_CONTROL_WHITESPACE_CHARACTER_CLASS}]*[\\t\\n\\r]` +
+    `[^${NON_CONTROL_WHITESPACE_CHARACTER_CLASS}]*`,
+  'g'
+);
+const SCHEMELESS_DOMAIN_SEPARATOR_PATTERN =
+  '(?:[.\\u3002\\uff0e\\uff61]|%2e|%e3%80%82|%ef%bc%8e|%ef%bd%a1)';
+const SCHEMELESS_DOMAIN_SEPARATOR_RUN_START_PATTERN =
+  '(?<![.\\u3002\\uff0e\\uff61])' +
+  '(?<!%2e)' +
+  '(?<!%e3%80%82)' +
+  '(?<!%ef%bc%8e)' +
+  '(?<!%ef%bd%a1)';
+const SCHEMELESS_PERCENT_ESCAPE_PATTERN = '%[0-9a-f]{2}';
+const SCHEMELESS_TOKEN_START_PATTERN = '(?<![^\\s<>"{}|\\\\^`\\[\\]])';
+const SCHEMELESS_USERINFO_START_PATTERN = `(?:${SCHEMELESS_TOKEN_START_PATTERN}|(?<=[/\\\\]{2}))`;
+const SCHEMELESS_DOMAIN_LABEL_CHARACTER_PATTERN =
+  '[^\\s./@:?#<>"{}|\\\\^`\\[\\]\\u3002\\uff0e\\uff61]';
+const SCHEMELESS_DOMAIN_LABEL_PATTERN =
+  `(?:(?!${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})` +
+  `${SCHEMELESS_DOMAIN_LABEL_CHARACTER_PATTERN})+`;
+const SCHEMELESS_DOMAIN_RE = new RegExp(
+  `(?<![\\p{L}\\p{N}%_.-])(?:www\\.)?${SCHEMELESS_DOMAIN_LABEL_PATTERN}` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN}${SCHEMELESS_DOMAIN_LABEL_PATTERN})+` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})?(?::[0-9]+)?(?:[/?#][^\\s]*)?`,
+  'giu'
+);
+const SCHEMELESS_EMPTY_LABEL_HOST_RE = new RegExp(
+  `(?:` +
+    `(?<![\\p{L}\\p{N}%_.-])${SCHEMELESS_DOMAIN_SEPARATOR_RUN_START_PATTERN}` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})+` +
+    `${SCHEMELESS_DOMAIN_LABEL_PATTERN}` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN}${SCHEMELESS_DOMAIN_LABEL_PATTERN})+|` +
+    `${SCHEMELESS_DOMAIN_SEPARATOR_RUN_START_PATTERN}` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN}){2,}${SCHEMELESS_DOMAIN_LABEL_PATTERN}` +
+    `)`,
+  'giu'
+);
+const SCHEMELESS_ASCII_OR_PERCENT_HOST_CHARACTER_PATTERN = `(?:[a-z0-9-]|${SCHEMELESS_PERCENT_ESCAPE_PATTERN})`;
+const SCHEMELESS_ASCII_OR_PERCENT_HOST_LABEL_PATTERN = `${SCHEMELESS_ASCII_OR_PERCENT_HOST_CHARACTER_PATTERN}+`;
+const SCHEMELESS_ASCII_OR_PERCENT_DOTTED_HOST_RE = new RegExp(
+  `(?<![a-zA-Z0-9%.-])${SCHEMELESS_ASCII_OR_PERCENT_HOST_LABEL_PATTERN}` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN}${SCHEMELESS_ASCII_OR_PERCENT_HOST_LABEL_PATTERN})+` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})?(?::[0-9]+)?(?:[/?#][^\\s]*)?`,
+  'gi'
+);
+const SCHEMELESS_IDNA_HOST_CHARACTER_PATTERN =
+  '(?:(?![<>"{}|\\\\^`\\[\\]\\u3002\\uff0e\\uff61])' +
+  '(?:[\\p{L}\\p{N}\\p{S}\\p{M}\\p{Cf}-]|(?=[^\\x00-\\x7f])\\p{P}))';
+const SCHEMELESS_IDNA_HOST_LABEL_PATTERN = `${SCHEMELESS_IDNA_HOST_CHARACTER_PATTERN}+`;
+const SCHEMELESS_ASCII_BOUNDARY_PATTERN =
+  '[\\s\\x21-\\x24\\x26-\\x2c\\x2f\\x3a-\\x40\\x5b-\\x60\\x7b-\\x7e]';
+const SCHEMELESS_IDNA_CANDIDATE_BOUNDARY_PATTERN =
+  `(?:(?<=${SCHEMELESS_ASCII_BOUNDARY_PATTERN})|` +
+  '(?<![\\p{L}\\p{N}\\p{S}\\p{M}\\p{Cf}\\p{P}%_.-]))';
+const SCHEMELESS_IDNA_DOTTED_HOST_RE = new RegExp(
+  `${SCHEMELESS_IDNA_CANDIDATE_BOUNDARY_PATTERN}${SCHEMELESS_IDNA_HOST_LABEL_PATTERN}` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN}${SCHEMELESS_IDNA_HOST_LABEL_PATTERN})+` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})?(?::[0-9]+)?(?:[/?#][^\\s]*)?`,
+  'giu'
+);
+const SCHEMELESS_IDNA_SPECIAL_HOST_WITH_SUFFIX_RE = new RegExp(
+  `${SCHEMELESS_IDNA_CANDIDATE_BOUNDARY_PATTERN}` +
+    `${SCHEMELESS_IDNA_HOST_LABEL_PATTERN}(?::[0-9]+)?[/?#][^\\s]*`,
+  'giu'
+);
+const SCHEMELESS_SPECIAL_HOST_BOUNDARY_PATTERN = '(?<![a-zA-Z0-9%])';
+const SCHEMELESS_IPV4_RE = new RegExp(
+  `${SCHEMELESS_SPECIAL_HOST_BOUNDARY_PATTERN}(?:[0-9]{1,3}\\.){3}` +
+    '[0-9]{1,3}(?::[0-9]+)?(?:[/?#][^\\s]*)?',
+  'g'
+);
+const SCHEMELESS_LEGACY_IPV4_RE = new RegExp(
+  `${SCHEMELESS_SPECIAL_HOST_BOUNDARY_PATTERN}(?:0x[0-9a-f]+|[0-9]+)` +
+    '(?:\\.(?:0x[0-9a-f]+|[0-9]+)){1,3}\\.?(?::[0-9]+)?(?:[/?#][^\\s]*)?',
+  'gi'
+);
+const SCHEMELESS_LEGACY_IPV4_NUMBER_PATTERN = '(?:0x[0-9a-f]+|[0-9]+)';
+const SCHEMELESS_ENCODED_LEGACY_IPV4_RE = new RegExp(
+  `${SCHEMELESS_SPECIAL_HOST_BOUNDARY_PATTERN}${SCHEMELESS_LEGACY_IPV4_NUMBER_PATTERN}` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN}${SCHEMELESS_LEGACY_IPV4_NUMBER_PATTERN}){1,3}` +
+    `(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})?(?::[0-9]+)?(?:[/?#][^\\s]*)?`,
+  'gi'
+);
+const SCHEMELESS_NUMERIC_IPV4_WITH_SUFFIX_RE = new RegExp(
+  `${SCHEMELESS_SPECIAL_HOST_BOUNDARY_PATTERN}[0-9]+(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})?` +
+    `(?::[0-9]+)?[/?#][^\\s]*`,
+  'g'
+);
+const SCHEMELESS_HEX_IPV4_WITH_SUFFIX_RE = new RegExp(
+  `${SCHEMELESS_SPECIAL_HOST_BOUNDARY_PATTERN}0x[0-9a-f]+(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})?` +
+    `(?::[0-9]+)?[/?#][^\\s]*`,
+  'gi'
+);
+const SCHEMELESS_PERCENT_ENCODED_HOST_PATTERN = `${SCHEMELESS_ASCII_OR_PERCENT_HOST_CHARACTER_PATTERN}+`;
+const SCHEMELESS_PERCENT_ENCODED_HOST_WITH_SUFFIX_RE = new RegExp(
+  `${SCHEMELESS_SPECIAL_HOST_BOUNDARY_PATTERN}${SCHEMELESS_PERCENT_ENCODED_HOST_PATTERN}` +
+    `(?::[0-9]+)?[/?#][^\\s]*`,
+  'gi'
+);
+const SCHEMELESS_IPV6_RE = new RegExp(
+  `${SCHEMELESS_SPECIAL_HOST_BOUNDARY_PATTERN}\\[[0-9a-f:.]+\\]` + '(?::[0-9]+)?(?:[/?#][^\\s]*)?',
+  'gi'
+);
+const SCHEMELESS_LOCALHOST_RE = new RegExp(
+  `${SCHEMELESS_SPECIAL_HOST_BOUNDARY_PATTERN}localhost(?:${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})?` +
+    `(?::[0-9]+)?(?:[/?#][^\\s]*)?`,
+  'gi'
+);
+const SCHEMELESS_USERINFO_URL_RE = new RegExp(
+  `${SCHEMELESS_USERINFO_START_PATTERN}[^\\s/]*@` +
+    `(?:\\[[0-9a-f:.]+\\]|[^\\s/?#<>"{}|\\\\^\`\\[\\]]+)` +
+    `(?:[/?#][^\\s]*)?`,
+  'giu'
+);
+const EMAIL_LOCAL_ATOM_SPECIAL_CHARACTERS = new Set("!#$%&'*+/=?^_`{|}~-");
+const EMAIL_UNICODE_LOCAL_ATOM_RE = /[\p{L}\p{N}\p{M}]/u;
+const EMAIL_DOT_CHARACTERS = new Set(['.', '\u3002', '\uff0e', '\uff61']);
+const TRAILING_SCHEMELESS_UNICODE_DOT_RE = /[\u3002\uff0e\uff61]+$/u;
+const EMAIL_TRAILING_BOUNDARY_RE = /[\s.,;!?()[\]{}<>\u3002\uff0e\uff61]/u;
+const EMAIL_HOST_SCAN_BOUNDARY_RE = /[\s,;!?()[\]{}<>/\\?:@]/u;
+// Keep whole-input scheme-less candidates when control removal moves a dotted
+// authority fragment across a userinfo or path boundary.
+const CONTROL_SEPARATED_SCHEMELESS_AUTHORITY_RE =
+  /^(?:(?:[\p{L}\p{N}-]+\.)+[\p{L}\p{N}-]*[\t\n\r][@\\/?#]|[\p{L}\p{N}-]+[\t\n\r][\\/]\.[\p{L}\p{N}-]+(?::\d+)?(?:[\\/?#]|$))/iu;
+// A disruptor adjacent to a dotted authority plus a trailing URL suffix
+// distinguishes these URL tokens from ordinary dotted filenames.
+const DISRUPTED_SCHEMELESS_DOTTED_AUTHORITY_RE =
+  /(?<![\p{L}\p{N}-])(?:[\p{L}\p{N}-]+(?:[\\/?#@;]|%2[ef]|%5c)+\.[\p{L}\p{N}-]+|[\p{L}\p{N}-]+\.(?:(?:[\\/?#@;]|%2[ef]|%5c)+[\p{L}\p{N}-]+|[\p{L}\p{N}-]+(?:[\\/?#@;]|%2[ef]|%5c)+[\p{L}\p{N}-]+))(?::\d+)?[\\/?#][^\s]*$/iu;
+type SchemelessCandidatePattern = {
+  pattern: RegExp;
+  shouldScan: (value: string) => boolean;
+  shouldInclude?: (candidate: string) => boolean;
+  shouldIncludeAt?: (value: string, start: number) => boolean;
+  allowNumericLeadingFinalLabel?: boolean;
+  ownsToken?: boolean;
+};
+const SCHEMELESS_DOMAIN_SEPARATOR_RE = new RegExp(SCHEMELESS_DOMAIN_SEPARATOR_PATTERN, 'i');
+const hasDomainSeparator = (value: string): boolean => SCHEMELESS_DOMAIN_SEPARATOR_RE.test(value);
+const hasUrlSuffix = (value: string): boolean => /[/?#]/.test(value);
+const hasNonAsciiCharacter = (value: string): boolean => {
+  for (let index = 0; index < value.length; index += 1) {
+    if (value.charCodeAt(index) > 0x7f) {
+      return true;
+    }
+  }
+  return false;
+};
+const getSchemelessAuthority = (value: string): string => value.split(/[\\/?#]/, 1)[0];
+const hasPercentOrPunycode = (value: string): boolean => value.includes('%') || /xn--/i.test(value);
+const hasPercentOrPunycodeInAuthority = (value: string): boolean =>
+  hasPercentOrPunycode(getSchemelessAuthority(value));
+const hasNonAsciiAuthority = (value: string): boolean =>
+  hasNonAsciiCharacter(getSchemelessAuthority(value));
+const hasExplicitPortInAuthority = (value: string): boolean =>
+  /:\d+$/.test(getSchemelessAuthority(value));
+const hasNonDnsAsciiPunctuationInAuthority = (value: string): boolean =>
+  /[!$&'()*+,=_~]/.test(getSchemelessAuthority(value));
+const isEmailLocalAtomCharacter = (character: string): boolean =>
+  isAsciiAlphanumeric(character) ||
+  EMAIL_LOCAL_ATOM_SPECIAL_CHARACTERS.has(character) ||
+  EMAIL_UNICODE_LOCAL_ATOM_RE.test(character);
+const isOrdinaryEmailLocalPart = (value: string): boolean => {
+  if (!value || value[0] === '.' || value.at(-1) === '.') {
+    return false;
+  }
+  let previousWasDot = false;
+  for (const character of value) {
+    if (character === '.') {
+      if (previousWasDot) {
+        return false;
+      }
+      previousWasDot = true;
+    } else {
+      if (!isEmailLocalAtomCharacter(character)) {
+        return false;
+      }
+      previousWasDot = false;
+    }
+  }
+  return true;
+};
+const isOrdinaryEmailHost = (value: string): boolean => {
+  if (!value || /[%\\/?#:@\s]/u.test(value)) {
+    return false;
+  }
+
+  let normalizedHostname: string;
+  try {
+    const parsedHost = new URL(`http://${value}`);
+    if (
+      parsedHost.username ||
+      parsedHost.password ||
+      parsedHost.port ||
+      parsedHost.pathname !== '/' ||
+      parsedHost.search ||
+      parsedHost.hash
+    ) {
+      return false;
+    }
+    normalizedHostname = parsedHost.hostname;
+  } catch {
+    return false;
+  }
+
+  const labels = normalizedHostname.split('.');
+  const finalLabel = labels.at(-1) ?? '';
+  if (labels.length < 2 || /^[0-9]/.test(finalLabel)) {
+    return false;
+  }
+  return labels.every(
+    (label) =>
+      label.length > 0 &&
+      isAsciiAlphanumeric(label[0]) &&
+      isAsciiAlphanumeric(label.at(-1) ?? '') &&
+      [...label].every((character) => isAsciiAlphanumeric(character) || character === '-')
+  );
+};
+const isOrdinaryEmailAddress = (value: string): boolean => {
+  const separator = value.indexOf('@');
+  return (
+    separator > 0 &&
+    separator === value.lastIndexOf('@') &&
+    isOrdinaryEmailLocalPart(value.slice(0, separator)) &&
+    isOrdinaryEmailHost(value.slice(separator + 1))
+  );
+};
+type OrdinaryEmailRange = {
+  start: number;
+  separator: number;
+  end: number;
+};
+const getPreviousCodePointStart = (value: string, end: number): number => {
+  const previous = value.charCodeAt(end - 1);
+  if (end >= 2 && previous >= 0xdc00 && previous <= 0xdfff) {
+    const leading = value.charCodeAt(end - 2);
+    if (leading >= 0xd800 && leading <= 0xdbff) {
+      return end - 2;
+    }
+  }
+  return end - 1;
+};
+const findOrdinaryEmailRangeAt = (text: string, separator: number): OrdinaryEmailRange | null => {
+  let localStart = separator;
+  while (localStart > 0) {
+    const previousStart = getPreviousCodePointStart(text, localStart);
+    const previousCharacter = text.slice(previousStart, localStart);
+    if (previousCharacter !== '.' && !isEmailLocalAtomCharacter(previousCharacter)) {
+      break;
+    }
+    localStart = previousStart;
+  }
+
+  let hostEnd = separator + 1;
+  while (hostEnd < text.length && !EMAIL_HOST_SCAN_BOUNDARY_RE.test(text[hostEnd])) {
+    hostEnd += 1;
+  }
+  while (hostEnd > separator + 1 && EMAIL_DOT_CHARACTERS.has(text[hostEnd - 1])) {
+    hostEnd -= 1;
+  }
+
+  const trailingCharacter = text[hostEnd] ?? '';
+  const characterAfterTrailing = text[hostEnd + 1] ?? '';
+  const hasEmailBoundary =
+    !trailingCharacter ||
+    (trailingCharacter === '?'
+      ? !characterAfterTrailing || EMAIL_TRAILING_BOUNDARY_RE.test(characterAfterTrailing)
+      : EMAIL_TRAILING_BOUNDARY_RE.test(trailingCharacter));
+  if (
+    !isOrdinaryEmailLocalPart(text.slice(localStart, separator)) ||
+    !isOrdinaryEmailHost(text.slice(separator + 1, hostEnd)) ||
+    !hasEmailBoundary
+  ) {
+    return null;
+  }
+
+  return { start: localStart, separator, end: hostEnd };
+};
+const hasExcludedUrlDelimiter = (value: string): boolean => /[<>"{}|\\^`\x5b\x5d]/.test(value);
+const isOutsidePath = (value: string, start: number): boolean =>
+  start === 0 || !/[\\/]/.test(value[start - 1]);
+const NORMAL_SCHEMELESS_EXTENDED_HOST_PATTERNS = [
+  {
+    pattern: SCHEMELESS_EMPTY_LABEL_HOST_RE,
+    shouldScan: hasDomainSeparator,
+    shouldIncludeAt: isOutsidePath,
+    allowNumericLeadingFinalLabel: true,
+    ownsToken: true,
+  },
+  {
+    pattern: SCHEMELESS_DOMAIN_RE,
+    shouldScan: hasDomainSeparator,
+    shouldInclude: hasExplicitPortInAuthority,
+    shouldIncludeAt: isOutsidePath,
+    allowNumericLeadingFinalLabel: true,
+    ownsToken: true,
+  },
+  {
+    pattern: SCHEMELESS_DOMAIN_RE,
+    shouldScan: hasDomainSeparator,
+    shouldInclude: (candidate) =>
+      hasNonDnsAsciiPunctuationInAuthority(candidate) && !isOrdinaryEmailAddress(candidate),
+    shouldIncludeAt: isOutsidePath,
+    allowNumericLeadingFinalLabel: true,
+    ownsToken: true,
+  },
+  {
+    pattern: SCHEMELESS_ASCII_OR_PERCENT_DOTTED_HOST_RE,
+    shouldScan: hasPercentOrPunycode,
+    shouldInclude: hasPercentOrPunycodeInAuthority,
+  },
+  {
+    pattern: SCHEMELESS_USERINFO_URL_RE,
+    shouldScan: (value: string) => value.includes('@'),
+    shouldInclude: (candidate: string) => !isOrdinaryEmailAddress(candidate),
+    allowNumericLeadingFinalLabel: true,
+  },
+  {
+    pattern: SCHEMELESS_IDNA_DOTTED_HOST_RE,
+    shouldScan: (value: string) => hasNonAsciiCharacter(value) && hasDomainSeparator(value),
+    shouldInclude: hasNonAsciiAuthority,
+    allowNumericLeadingFinalLabel: true,
+  },
+  {
+    pattern: SCHEMELESS_IDNA_SPECIAL_HOST_WITH_SUFFIX_RE,
+    shouldScan: (value: string) => hasNonAsciiCharacter(value) && hasUrlSuffix(value),
+    shouldInclude: hasNonAsciiAuthority,
+    allowNumericLeadingFinalLabel: true,
+  },
+] satisfies SchemelessCandidatePattern[];
+const SCHEMELESS_CANDIDATE_PATTERNS = [
+  {
+    pattern: SCHEMELESS_EMPTY_LABEL_HOST_RE,
+    shouldScan: hasDomainSeparator,
+    allowNumericLeadingFinalLabel: true,
+  },
+  { pattern: SCHEMELESS_DOMAIN_RE, shouldScan: hasDomainSeparator },
+  {
+    pattern: SCHEMELESS_ASCII_OR_PERCENT_DOTTED_HOST_RE,
+    shouldScan: hasDomainSeparator,
+    shouldInclude: hasPercentOrPunycodeInAuthority,
+  },
+  {
+    pattern: SCHEMELESS_IDNA_DOTTED_HOST_RE,
+    shouldScan: (value) => hasNonAsciiCharacter(value) && hasDomainSeparator(value),
+    shouldInclude: hasNonAsciiAuthority,
+    allowNumericLeadingFinalLabel: true,
+  },
+  {
+    pattern: SCHEMELESS_IDNA_SPECIAL_HOST_WITH_SUFFIX_RE,
+    shouldScan: (value) => hasNonAsciiCharacter(value) && hasUrlSuffix(value),
+    shouldInclude: hasNonAsciiAuthority,
+    allowNumericLeadingFinalLabel: true,
+  },
+  { pattern: SCHEMELESS_IPV4_RE, shouldScan: (value) => value.includes('.') },
+  { pattern: SCHEMELESS_LEGACY_IPV4_RE, shouldScan: (value) => value.includes('.') },
+  { pattern: SCHEMELESS_ENCODED_LEGACY_IPV4_RE, shouldScan: hasDomainSeparator },
+  { pattern: SCHEMELESS_NUMERIC_IPV4_WITH_SUFFIX_RE, shouldScan: hasUrlSuffix },
+  { pattern: SCHEMELESS_HEX_IPV4_WITH_SUFFIX_RE, shouldScan: hasUrlSuffix },
+  {
+    pattern: SCHEMELESS_PERCENT_ENCODED_HOST_WITH_SUFFIX_RE,
+    shouldScan: (value) => value.includes('%') && hasUrlSuffix(value),
+  },
+  { pattern: SCHEMELESS_IPV6_RE, shouldScan: (value) => value.includes('[') },
+  { pattern: SCHEMELESS_LOCALHOST_RE, shouldScan: (value) => /localhost/i.test(value) },
+  {
+    pattern: SCHEMELESS_USERINFO_URL_RE,
+    shouldScan: (value) => value.includes('@'),
+    shouldInclude: (candidate) => !isOrdinaryEmailAddress(candidate),
+  },
+] satisfies SchemelessCandidatePattern[];
+
+type UrlCandidate = {
+  value: string;
+  start: number;
+  end: number;
+};
+
+type UserinfoBridgeOwner = UrlCandidate & {
+  parseMode: 'explicit' | 'scheme-relative' | 'scheme-less';
+};
+
+type WhitespaceBridgedUserinfoCandidate = UrlCandidate & {
+  independentOwner?: UrlCandidate;
+};
+
+function findFirstPositionAtOrAfter(positions: number[], target: number): number | null {
+  let low = 0;
+  let high = positions.length - 1;
+  let match: number | null = null;
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    if (positions[middle] >= target) {
+      match = positions[middle];
+      high = middle - 1;
+    } else {
+      low = middle + 1;
+    }
+  }
+
+  return match;
+}
+
+function findLastPositionBefore(positions: number[], limit: number): number | null {
+  let low = 0;
+  let high = positions.length - 1;
+  let match: number | null = null;
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    if (positions[middle] < limit) {
+      match = positions[middle];
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+
+  return match;
+}
+
+function cleanAmbiguousUrlCandidate(candidate: string): string {
+  // Resolve the token boundary before punctuation cleanup so a control directly
+  // before closing prose punctuation remains internal and cannot be hidden.
+  const withoutTrailingControls = candidate.replace(TRAILING_URL_CONTROL_RE, '');
+  if (
+    ASCII_URL_CONTROL_RE.test(candidate) &&
+    DETECTED_HOSTLESS_SCHEME_ONLY_RE.test(withoutTrailingControls)
+  ) {
+    // Keep the raw control so a scheme-only token cannot disappear after cleanup.
+    return candidate;
+  }
+  return withoutTrailingControls;
+}
+
+function cleanTrailingSchemelessUnicodeDots(candidate: string): string {
+  if (/[/?#]/.test(candidate)) {
+    return candidate;
+  }
+  return candidate.replace(TRAILING_SCHEMELESS_UNICODE_DOT_RE, '');
+}
+
+const TRAILING_AUTHORITY_PROSE_PUNCTUATION_RE = /[.,;:!]+$/;
+const TRAILING_WRAPPER_EXTERNAL_PUNCTUATION_RE = /[.,;:!?。、，；：！？．｡]+$/;
+const URL_WRAPPER_PAIRS = new Map([
+  ['(', ')'],
+  ['[', ']'],
+  ['{', '}'],
+  ['<', '>'],
+  ['（', '）'],
+  ['［', '］'],
+  ['「', '」'],
+  ['『', '』'],
+  ['【', '】'],
+  ['〈', '〉'],
+  ['《', '》'],
+]);
+const REPEATED_URL_WRAPPERS = new Set(['*', '_', '~', "'", '"', '`', '|']);
+// Malformed wrapper-only prefixes otherwise cause repeated scans of the same
+// suffix. Beyond this depth, preserve fail-closed token ownership instead.
+const MAX_WRAPPER_PREFIX_DESCENT = 64;
+
+function isUrlWrapperOpeningCharacter(character: string): boolean {
+  return URL_WRAPPER_PAIRS.has(character) || REPEATED_URL_WRAPPERS.has(character);
+}
+
+function getClosingUrlWrapper(text: string, start: number): string {
+  let wrapperEnd = start;
+  while (wrapperEnd > 0 && /[ \v\f]/.test(text[wrapperEnd - 1])) {
+    wrapperEnd -= 1;
+  }
+  const hasWhitespaceGap = wrapperEnd < start;
+  if (hasWhitespaceGap && !URL_WRAPPER_PAIRS.has(text[wrapperEnd - 1] ?? '')) {
+    return '';
+  }
+
+  let wrapperStart = wrapperEnd;
+  while (wrapperStart > 0 && isUrlWrapperOpeningCharacter(text[wrapperStart - 1])) {
+    wrapperStart -= 1;
+  }
+  if (wrapperStart === wrapperEnd) {
+    return '';
+  }
+  const openingWrapper = text.slice(wrapperStart, wrapperEnd);
+
+  const closingParts: string[] = [];
+  for (let index = 0; index < openingWrapper.length; ) {
+    const character = openingWrapper[index];
+    if (REPEATED_URL_WRAPPERS.has(character)) {
+      let end = index + 1;
+      while (end < openingWrapper.length && openingWrapper[end] === character) {
+        end += 1;
+      }
+      closingParts.push(openingWrapper.slice(index, end));
+      index = end;
+      continue;
+    }
+    closingParts.push(URL_WRAPPER_PAIRS.get(character) ?? '');
+    index += 1;
+  }
+
+  return closingParts.reverse().join('');
+}
+
+function cleanPairedUrlWrapper(candidate: string, text: string, start: number): string {
+  const closingWrapper = getClosingUrlWrapper(text, start);
+  if (!closingWrapper) {
+    return candidate;
+  }
+
+  const withoutExternalPunctuation = candidate.replace(
+    TRAILING_WRAPPER_EXTERNAL_PUNCTUATION_RE,
+    ''
+  );
+  if (!withoutExternalPunctuation.endsWith(closingWrapper)) {
+    return candidate;
+  }
+
+  return withoutExternalPunctuation.slice(0, -closingWrapper.length);
+}
+
+function unwrapPairedUrlWrapper(candidate: string, text: string, start: number): UrlCandidate {
+  let candidateOffset = 0;
+  while (
+    candidateOffset < candidate.length &&
+    isUrlWrapperOpeningCharacter(candidate[candidateOffset])
+  ) {
+    if (
+      candidate[candidateOffset] === '[' &&
+      /^\[(?=[0-9a-f.]*:)[0-9a-f:.]+\](?::[0-9]+)?/i.test(candidate.slice(candidateOffset))
+    ) {
+      break;
+    }
+    candidateOffset += 1;
+  }
+
+  if (candidateOffset === 0) {
+    return { value: candidate, start, end: start + candidate.length };
+  }
+
+  const innerStart = start + candidateOffset;
+  const innerCandidate = candidate.slice(candidateOffset);
+  const cleaned = cleanPairedUrlWrapper(innerCandidate, text, innerStart);
+  if (cleaned === innerCandidate) {
+    return { value: candidate, start, end: start + candidate.length };
+  }
+
+  return { value: cleaned, start: innerStart, end: innerStart + cleaned.length };
+}
+
+function cleanTrailingAuthorityProsePunctuation(
+  candidate: string,
+  text: string,
+  start: number
+): string {
+  const explicitScheme = candidate.match(/^([a-z][a-z0-9+.-]*):/i);
+  let authorityStart: number;
+
+  if (explicitScheme) {
+    const scheme = explicitScheme[1].toLowerCase();
+    const schemeEnd = explicitScheme[0].length;
+    const hasAuthorityPrefix = /^[\\/]{2}/.test(candidate.slice(schemeEnd));
+    if (!AUTHORITY_SCHEMES.includes(scheme) && !hasAuthorityPrefix) {
+      return candidate;
+    }
+    authorityStart = schemeEnd;
+    if (scheme === 'file' || !AUTHORITY_SCHEMES.includes(scheme)) {
+      if (!hasAuthorityPrefix) {
+        return candidate;
+      }
+      authorityStart += 2;
+    } else {
+      while (authorityStart < candidate.length && /[\\/]/.test(candidate[authorityStart])) {
+        authorityStart += 1;
+      }
+    }
+  } else if (/^[\\/]{2}/.test(candidate)) {
+    authorityStart = 0;
+    while (authorityStart < candidate.length && /[\\/]/.test(candidate[authorityStart])) {
+      authorityStart += 1;
+    }
+  } else {
+    return candidate;
+  }
+
+  let cleaned = cleanPairedUrlWrapper(candidate, text, start);
+  if (/[\\/?#]/.test(cleaned.slice(authorityStart))) {
+    return cleaned;
+  }
+
+  let previous: string;
+  do {
+    previous = cleaned;
+    cleaned = cleaned.replace(TRAILING_AUTHORITY_PROSE_PUNCTUATION_RE, '');
+
+    for (const [opening, closing] of [
+      ['(', ')'],
+      ['[', ']'],
+    ] as const) {
+      if (!cleaned.endsWith(closing)) {
+        continue;
+      }
+      const authority = cleaned.slice(authorityStart);
+      const openingCount = authority.split(opening).length - 1;
+      const closingCount = authority.split(closing).length - 1;
+      if (closingCount > openingCount) {
+        cleaned = cleaned.slice(0, -1);
+      }
+    }
+  } while (cleaned !== previous);
+
+  return cleaned;
+}
+
+function cleanExcludedAuthorityPairedWrapper(
+  candidate: string,
+  text: string,
+  start: number
+): string {
+  const closingWrapper = getClosingUrlWrapper(text, start);
+  if (!closingWrapper) {
+    return candidate;
+  }
+
+  for (
+    let closingStart = candidate.indexOf(closingWrapper);
+    closingStart >= 0;
+    closingStart = candidate.indexOf(closingWrapper, closingStart + closingWrapper.length)
+  ) {
+    if (!isEscapedUrlDelimiter(candidate, closingStart)) {
+      return candidate.slice(0, closingStart);
+    }
+  }
+
+  return candidate;
+}
+
+function hasInternalUrlControl(candidate: string): boolean {
+  return ASCII_URL_CONTROL_RE.test(candidate);
+}
+
+function normalizeHostnameForComparison(hostname: string): string {
+  return hostname.toLowerCase().replace(/\.$/, '');
+}
+
+function isSupportedHostname(hostname: string, allowNumericLeadingFinalLabel = false): boolean {
+  const normalizedHostname = normalizeHostnameForComparison(hostname);
+  if (
+    normalizedHostname === 'localhost' ||
+    isIpv4Address(normalizedHostname) ||
+    (normalizedHostname.startsWith('[') && normalizedHostname.endsWith(']'))
+  ) {
+    return true;
+  }
+
+  const finalLabel = normalizedHostname.split('.').pop() ?? '';
+  const unsupportedFinalLabel = allowNumericLeadingFinalLabel
+    ? /^[0-9]+$/.test(finalLabel)
+    : /^[0-9]/.test(finalLabel);
+  return normalizedHostname.includes('.') && !unsupportedFinalLabel;
+}
+
+function isSupportedSchemelessUrlCandidate(
+  candidate: string,
+  allowNumericLeadingFinalLabel = false
+): boolean {
+  try {
+    return isSupportedHostname(
+      new URL(`http://${candidate}`).hostname,
+      allowNumericLeadingFinalLabel
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isSupportedSchemeRelativeUrlCandidate(candidate: string): boolean {
+  if (!/^[\\/]{2}/.test(candidate)) {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(candidate, SCHEME_RELATIVE_BASE_URL);
+    const authorityAndSuffix = candidate.replace(/^[\\/]+/, '');
+    const hasExplicitSuffix = /[\\/?#]/.test(authorityAndSuffix);
+    const hostnameWithoutTrailingDot = normalizeHostnameForComparison(parsedUrl.hostname);
+    return (
+      Boolean(parsedUrl.username || parsedUrl.password || parsedUrl.port) ||
+      hasExplicitSuffix ||
+      hostnameWithoutTrailingDot.includes('.') ||
+      isSupportedHostname(parsedUrl.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function detectAmbiguousSchemelessUrls(text: string): UrlCandidate[] {
+  const candidates: UrlCandidate[] = [];
+  const seenRanges = new Set<string>();
+
+  CONTROL_BEARING_TOKEN_RE.lastIndex = 0;
+  for (const tokenResult of text.matchAll(CONTROL_BEARING_TOKEN_RE)) {
+    const rawToken = tokenResult[0];
+    const tokenStart = tokenResult.index;
+    const normalizedCharacters: string[] = [];
+    const rawPositions: number[] = [];
+
+    for (let rawIndex = 0; rawIndex < rawToken.length; rawIndex += 1) {
+      const character = rawToken[rawIndex];
+      if (ASCII_URL_CONTROL_RE.test(character)) {
+        continue;
+      }
+      normalizedCharacters.push(character);
+      rawPositions.push(rawIndex);
+    }
+
+    const normalizedToken = normalizedCharacters.join('');
+    const detectedSchemePosition = normalizedToken.search(DETECTED_SCHEME_IN_TOKEN_RE);
+    for (const {
+      pattern,
+      shouldScan,
+      shouldInclude,
+      allowNumericLeadingFinalLabel,
+    } of SCHEMELESS_CANDIDATE_PATTERNS) {
+      if (!shouldScan(normalizedToken)) {
+        continue;
+      }
+      pattern.lastIndex = 0;
+      for (const normalizedResult of normalizedToken.matchAll(pattern)) {
+        const normalizedStart = normalizedResult.index;
+        if (detectedSchemePosition >= 0 && detectedSchemePosition < normalizedStart) {
+          continue;
+        }
+        const normalizedCandidate = cleanAmbiguousUrlCandidate(normalizedResult[0]);
+        if (shouldInclude && !shouldInclude(normalizedCandidate)) {
+          continue;
+        }
+        if (
+          !isSupportedSchemelessUrlCandidate(normalizedCandidate, allowNumericLeadingFinalLabel)
+        ) {
+          continue;
+        }
+        const normalizedEnd = normalizedStart + normalizedCandidate.length;
+        const rawStart = tokenStart + rawPositions[normalizedStart];
+        const rawEnd =
+          tokenStart +
+          (normalizedEnd < rawPositions.length ? rawPositions[normalizedEnd] : rawToken.length);
+        const rawCandidate = text.slice(rawStart, rawEnd);
+        const candidateRemainder = text.slice(rawStart, tokenStart + rawToken.length);
+        const explicitAuthorityBoundary = candidateRemainder.search(
+          EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_RE
+        );
+        const value = cleanAmbiguousUrlCandidate(
+          explicitAuthorityBoundary >= 0
+            ? rawCandidate.slice(0, explicitAuthorityBoundary)
+            : rawCandidate
+        );
+
+        if (!hasInternalUrlControl(value)) {
+          continue;
+        }
+
+        const end = rawStart + value.length;
+        const rangeKey = `${rawStart}:${end}`;
+        if (!seenRanges.has(rangeKey)) {
+          candidates.push({ value, start: rawStart, end });
+          seenRanges.add(rangeKey);
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function detectControlObfuscatedSchemeRelativeUrls(text: string): UrlCandidate[] {
+  const candidates: UrlCandidate[] = [];
+
+  CONTROL_BEARING_TOKEN_RE.lastIndex = 0;
+  for (const tokenResult of text.matchAll(CONTROL_BEARING_TOKEN_RE)) {
+    const rawToken = tokenResult[0];
+    const tokenStart = tokenResult.index;
+    const normalizedCharacters: string[] = [];
+    const rawPositions: number[] = [];
+
+    for (let rawIndex = 0; rawIndex < rawToken.length; rawIndex += 1) {
+      const character = rawToken[rawIndex];
+      if (ASCII_URL_CONTROL_RE.test(character)) {
+        continue;
+      }
+      normalizedCharacters.push(character);
+      rawPositions.push(rawIndex);
+    }
+
+    const normalizedToken = normalizedCharacters.join('');
+    SCHEME_RELATIVE_URL_RE.lastIndex = 0;
+    for (const normalizedResult of normalizedToken.matchAll(SCHEME_RELATIVE_URL_RE)) {
+      const normalizedStart = normalizedResult.index;
+      const normalizedEnd = normalizedStart + normalizedResult[0].length;
+      const rawStart = tokenStart + rawPositions[normalizedStart];
+      const mappedRawEnd =
+        tokenStart +
+        (normalizedEnd < rawPositions.length ? rawPositions[normalizedEnd] : rawToken.length);
+      let value = text.slice(rawStart, mappedRawEnd);
+
+      const explicitAuthorityBoundary = value.search(EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_RE);
+      if (explicitAuthorityBoundary >= 0) {
+        value = value.slice(0, explicitAuthorityBoundary);
+      }
+      value = cleanAmbiguousUrlCandidate(value);
+
+      if (
+        !hasInternalUrlControl(value) ||
+        !isSupportedSchemeRelativeUrlCandidate(value.replace(/[\t\n\r]/g, ''))
+      ) {
+        continue;
+      }
+
+      candidates.push({ value, start: rawStart, end: rawStart + value.length });
+    }
+  }
+
+  return candidates;
+}
+
+function isAsciiSchemeStart(character: string): boolean {
+  const codePoint = character.charCodeAt(0);
+  return (codePoint >= 0x41 && codePoint <= 0x5a) || (codePoint >= 0x61 && codePoint <= 0x7a);
+}
+
+function isAsciiAlphanumeric(character: string): boolean {
+  const codePoint = character.charCodeAt(0);
+  return isAsciiSchemeStart(character) || (codePoint >= 0x30 && codePoint <= 0x39);
+}
+
+function hasPotentialAsciiDomainFinalLabel(value: string): boolean {
+  for (let dot = value.indexOf('.'); dot >= 0; dot = value.indexOf('.', dot + 1)) {
+    if (isAsciiSchemeStart(value[dot + 1] ?? '') && isAsciiSchemeStart(value[dot + 2] ?? '')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isAsciiSchemeCharacter(character: string): boolean {
+  const codePoint = character.charCodeAt(0);
+  return (
+    isAsciiSchemeStart(character) ||
+    (codePoint >= 0x30 && codePoint <= 0x39) ||
+    character === '+' ||
+    character === '.' ||
+    character === '-'
+  );
+}
+
+type DetectedUrlPrefix = {
+  index: number;
+  end: number;
+};
+
+// Find colon-delimited scheme runs directly so a long scheme-character token
+// is scanned linearly instead of retrying a greedy scheme regexp at each offset.
+function findDetectedUrlPrefixInToken(value: string): DetectedUrlPrefix | null {
+  for (let colon = value.indexOf(':'); colon >= 0; colon = value.indexOf(':', colon + 1)) {
+    let schemeRunStart = colon;
+    while (schemeRunStart > 0 && isAsciiSchemeCharacter(value[schemeRunStart - 1])) {
+      schemeRunStart -= 1;
+    }
+    let schemeStart = schemeRunStart;
+    while (
+      schemeStart < colon &&
+      (!isAsciiSchemeStart(value[schemeStart]) ||
+        (schemeStart > 0 && isAsciiAlphanumeric(value[schemeStart - 1])))
+    ) {
+      schemeStart += 1;
+    }
+    if (schemeStart === colon) {
+      continue;
+    }
+
+    const hasAuthorityPrefix = value[colon + 1] === '/' && value[colon + 2] === '/';
+    if (!hasAuthorityPrefix) {
+      const scheme = value.slice(schemeStart, colon).toLowerCase();
+      if (!DETECTED_SCHEMES.has(scheme)) {
+        continue;
+      }
+    }
+
+    return {
+      index: schemeStart === 0 ? 0 : schemeStart - 1,
+      end: colon + (hasAuthorityPrefix ? 3 : 1),
+    };
+  }
+
+  return null;
+}
+
+function hasStandaloneSchemeStart(text: string, index: number): boolean {
+  let runStart = index;
+  while (runStart > 0 && isAsciiSchemeCharacter(text[runStart - 1])) {
+    runStart -= 1;
+  }
+  while (runStart < index && /[+.-]/.test(text[runStart])) {
+    runStart += 1;
+  }
+  return runStart === index;
+}
+
+function detectControlObfuscatedGenericSchemes(text: string): UrlCandidate[] {
+  const candidates: UrlCandidate[] = [];
+
+  CONTROL_BEARING_TOKEN_RE.lastIndex = 0;
+  for (const tokenResult of text.matchAll(CONTROL_BEARING_TOKEN_RE)) {
+    const rawToken = tokenResult[0];
+    const tokenStart = tokenResult.index;
+    const firstDetectedUrl = findDetectedUrlPrefixInToken(rawToken);
+    const firstDetectedUrlEnd = firstDetectedUrl?.end ?? Number.POSITIVE_INFINITY;
+
+    for (let index = 0; index < rawToken.length; index += 1) {
+      if (!isAsciiSchemeStart(rawToken[index]) || !hasStandaloneSchemeStart(rawToken, index)) {
+        continue;
+      }
+      if (firstDetectedUrlEnd <= index) {
+        continue;
+      }
+
+      let cursor = index + 1;
+      let hasControl = false;
+      while (cursor < rawToken.length) {
+        const character = rawToken[cursor];
+        if (isAsciiSchemeCharacter(character)) {
+          cursor += 1;
+          continue;
+        }
+        if (ASCII_URL_CONTROL_RE.test(character)) {
+          hasControl = true;
+          cursor += 1;
+          continue;
+        }
+        break;
+      }
+
+      if (!hasControl || rawToken[cursor] !== ':' || cursor + 1 >= rawToken.length) {
+        index = cursor;
+        continue;
+      }
+
+      const potentialBoundary = rawToken
+        .slice(index)
+        .search(EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_RE);
+      if (potentialBoundary >= 0 && index + potentialBoundary < cursor) {
+        const precedingCandidate = cleanAmbiguousUrlCandidate(
+          rawToken.slice(index, index + potentialBoundary)
+        );
+        const precedingToken = cleanAmbiguousUrlCandidate(
+          rawToken.slice(0, index + potentialBoundary)
+        );
+        if (
+          (hasUrlSuffix(precedingCandidate) &&
+            isSupportedSchemelessUrlCandidate(precedingCandidate, true)) ||
+          (hasUrlSuffix(precedingToken) &&
+            hasPotentialWrappedSchemelessUrlStart(precedingToken) &&
+            isSupportedSchemelessUrlCandidate(precedingToken, true)) ||
+          isSupportedSchemeRelativeUrlCandidate(precedingToken)
+        ) {
+          index = cursor;
+          continue;
+        }
+      }
+
+      const remainder = rawToken.slice(cursor + 1);
+      const nextExplicitAuthority = remainder.search(EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_RE);
+      const rawEnd =
+        nextExplicitAuthority >= 0 ? cursor + 1 + nextExplicitAuthority : rawToken.length;
+      const value = cleanAmbiguousUrlCandidate(rawToken.slice(index, rawEnd));
+
+      try {
+        const parsedUrl = new URL(value);
+        const normalizedScheme = rawToken
+          .slice(index, cursor)
+          .replace(/[\t\n\r]/g, '')
+          .toLowerCase();
+        if (parsedUrl.protocol.toLowerCase() !== `${normalizedScheme}:`) {
+          index = cursor;
+          continue;
+        }
+      } catch {
+        index = cursor;
+        continue;
+      }
+
+      const start = tokenStart + index;
+      candidates.push({ value, start, end: start + value.length });
+      index = cursor;
+    }
+  }
+
+  return candidates;
+}
+
+function mergeAmbiguousUrlCandidates(text: string, candidates: UrlCandidate[]): UrlCandidate[] {
+  const sortedCandidates = [...candidates].sort(
+    (left, right) => left.start - right.start || right.end - left.end
+  );
+  const mergedCandidates: UrlCandidate[] = [];
+
+  for (const candidate of sortedCandidates) {
+    const previous = mergedCandidates[mergedCandidates.length - 1];
+    if (!previous || candidate.start >= previous.end) {
+      mergedCandidates.push(candidate);
+      continue;
+    }
+
+    if (candidate.end <= previous.end) {
+      continue;
+    }
+
+    const value = cleanAmbiguousUrlCandidate(text.slice(previous.start, candidate.end));
+    previous.value = value;
+    previous.end = previous.start + value.length;
+  }
+
+  return mergedCandidates;
+}
+
+function detectEntireInputAmbiguousUrl(text: string): UrlCandidate | null {
+  const value = text.trim();
+  if (!value || !ASCII_URL_CONTROL_RE.test(value) || EXPLICIT_URL_LINE_BOUNDARY_RE.test(value)) {
+    return null;
+  }
+
+  const start = text.indexOf(value);
+  try {
+    const parsedUrl = new URL(value);
+    const scheme = parsedUrl.protocol.replace(/:$/, '').toLowerCase();
+    if (DETECTED_SCHEMES.has(scheme)) {
+      return { value, start, end: start + value.length };
+    }
+  } catch {
+    // Fall through to the scheme-less parse below.
+  }
+
+  try {
+    const parsedUrl = new URL(`http://${value}`);
+    const normalizedValue = value.replace(/[\t\n\r]/g, '');
+    const startsWithSupportedSchemelessUrl =
+      /^(?:[a-z0-9]|\[)/i.test(normalizedValue) &&
+      SCHEMELESS_CANDIDATE_PATTERNS.some(
+        ({ pattern, shouldScan, shouldInclude, allowNumericLeadingFinalLabel }) => {
+          if (!shouldScan(normalizedValue)) {
+            return false;
+          }
+          pattern.lastIndex = 0;
+          const match = pattern.exec(normalizedValue);
+          return (
+            match?.index === 0 &&
+            (!shouldInclude || shouldInclude(match[0])) &&
+            isSupportedSchemelessUrlCandidate(match[0], allowNumericLeadingFinalLabel)
+          );
+        }
+      );
+    const normalizedHostname = normalizeHostnameForComparison(parsedUrl.hostname);
+    const firstCodePoint = normalizedValue.codePointAt(0) ?? 0;
+    const hasStrongWholeInputSchemelessSyntax =
+      CONTROL_SEPARATED_SCHEMELESS_AUTHORITY_RE.test(value);
+    const isSupportedWholeInputSpecialHost =
+      (/^(?:[a-z0-9%@]|\[)/i.test(normalizedValue) || firstCodePoint > 0x7f) &&
+      (normalizedHostname === 'localhost' ||
+        isIpv4Address(normalizedHostname) ||
+        (normalizedHostname.startsWith('[') && normalizedHostname.endsWith(']')));
+    if (
+      !startsWithSupportedSchemelessUrl &&
+      !hasStrongWholeInputSchemelessSyntax &&
+      !isSupportedWholeInputSpecialHost
+    ) {
+      return null;
+    }
+    return { value, start, end: start + value.length };
+  } catch {
+    return null;
+  }
+}
+
+function isDisruptedSchemelessUrlCandidate(value: string, requireStructuralStart = false): boolean {
+  if (
+    !value ||
+    ASCII_URL_CONTROL_RE.test(value) ||
+    URL_WHITESPACE_RE.test(value) ||
+    !hasUrlSuffix(value) ||
+    findDetectedUrlPrefixInToken(value)
+  ) {
+    return false;
+  }
+
+  const structuralResult = DISRUPTED_SCHEMELESS_DOTTED_AUTHORITY_RE.exec(value);
+  if (!structuralResult || (requireStructuralStart && structuralResult.index !== 0)) {
+    return false;
+  }
+  const structuralMatch = structuralResult[0];
+  try {
+    const parsedUrl = new URL(`http://${structuralMatch}`);
+    return Boolean(parsedUrl.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function hasPotentialWrappedSchemelessUrlStart(candidate: string): boolean {
+  const firstCodePoint = candidate.codePointAt(0) ?? 0;
+  return /^[a-z0-9%]/i.test(candidate) || candidate[0] === '[' || firstCodePoint > 0x7f;
+}
+
+function isSupportedWrappedSchemelessUrlCandidate(candidate: string): boolean {
+  if (!hasPotentialWrappedSchemelessUrlStart(candidate)) {
+    return false;
+  }
+  if (!isSupportedSchemelessUrlCandidate(candidate)) {
+    return false;
+  }
+
+  const authority = getSchemelessAuthority(candidate);
+  return (
+    hasDomainSeparator(authority) ||
+    /^localhost(?::|$)/i.test(authority) ||
+    authority.startsWith('[') ||
+    hasUrlSuffix(candidate)
+  );
+}
+
+function isEscapedUrlDelimiter(value: string, index: number): boolean {
+  let backslashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor -= 1) {
+    backslashCount += 1;
+  }
+  return backslashCount % 2 === 1;
+}
+
+function findWrappedSchemelessUrlCandidates(
+  value: string,
+  text: string,
+  start: number
+): UrlCandidate[] {
+  const externallyWrapped = cleanPairedUrlWrapper(value, text, start);
+  if (externallyWrapped !== value && isSupportedWrappedSchemelessUrlCandidate(externallyWrapped)) {
+    return [
+      {
+        value: externallyWrapped,
+        start,
+        end: start + externallyWrapped.length,
+      },
+    ];
+  }
+
+  const candidates: UrlCandidate[] = [];
+  // Wrapper queries move forward with `offset`. Cache the first occurrence at
+  // or after each query so distant suffixes are scanned once per character.
+  const nextPairedWrapperPositions = new Map<string, number>();
+  const findNextPairedWrapperPosition = (character: string, searchStart: number): number => {
+    const cachedPosition = nextPairedWrapperPositions.get(character);
+    if (cachedPosition !== undefined && (cachedPosition < 0 || cachedPosition >= searchStart)) {
+      return cachedPosition;
+    }
+
+    const nextPosition = value.indexOf(character, searchStart);
+    nextPairedWrapperPositions.set(character, nextPosition);
+    return nextPosition;
+  };
+  for (let offset = 0; offset < value.length; ) {
+    if (!isUrlWrapperOpeningCharacter(value[offset])) {
+      offset += 1;
+      continue;
+    }
+
+    const wrapperStart = offset;
+    while (offset < value.length && isUrlWrapperOpeningCharacter(value[offset])) {
+      offset += 1;
+    }
+    const wrapperPrefixEnd = offset;
+
+    const openingCharacter = value[wrapperStart];
+    let repeatedWrapperEnd = wrapperStart + 1;
+    while (repeatedWrapperEnd < value.length && value[repeatedWrapperEnd] === openingCharacter) {
+      repeatedWrapperEnd += 1;
+    }
+    const previousCharacter = value[wrapperStart - 1] ?? '';
+    const isPairedWrapper = URL_WRAPPER_PAIRS.has(openingCharacter);
+    const isSharedDelimiter = openingCharacter === '|';
+    const followsSameRepeatedWrapper =
+      REPEATED_URL_WRAPPERS.has(openingCharacter) && previousCharacter === openingCharacter;
+    if (
+      /[\\/]/.test(previousCharacter) ||
+      (!isPairedWrapper &&
+        !isSharedDelimiter &&
+        !followsSameRepeatedWrapper &&
+        /[\p{L}\p{N}%_.-]/u.test(previousCharacter))
+    ) {
+      offset = wrapperStart + 1;
+      continue;
+    }
+
+    const closingCharacter = URL_WRAPPER_PAIRS.get(openingCharacter) ?? openingCharacter;
+    const pairedClosingStart = isPairedWrapper
+      ? findNextPairedWrapperPosition(closingCharacter, repeatedWrapperEnd)
+      : -1;
+    if (isPairedWrapper && pairedClosingStart < 0) {
+      const wrapperPrefixLength = wrapperPrefixEnd - wrapperStart;
+      offset =
+        wrapperPrefixLength > MAX_WRAPPER_PREFIX_DESCENT ? wrapperPrefixEnd : wrapperStart + 1;
+      continue;
+    }
+
+    const nextPairedOpeningStart = isPairedWrapper
+      ? findNextPairedWrapperPosition(openingCharacter, repeatedWrapperEnd)
+      : -1;
+    const hasAnotherPairedOpening = nextPairedOpeningStart >= 0;
+    const repeatedWrapper = value.slice(wrapperStart, repeatedWrapperEnd);
+    const firstRepeatedClosing = value.indexOf(repeatedWrapper, repeatedWrapperEnd);
+    const nextRepeatedOpening =
+      firstRepeatedClosing < 0
+        ? -1
+        : value.indexOf(repeatedWrapper, firstRepeatedClosing + repeatedWrapper.length);
+    const repeatedWrapperSeparator =
+      nextRepeatedOpening < 0
+        ? ''
+        : value.slice(firstRepeatedClosing + repeatedWrapper.length, nextRepeatedOpening);
+    const hasFollowingRepeatedValue =
+      !isPairedWrapper && nextRepeatedOpening >= 0 && /^[,;:]?$/.test(repeatedWrapperSeparator);
+    const hasAnotherSharedValue = isSharedDelimiter && nextRepeatedOpening >= 0;
+    if (!hasAnotherPairedOpening && !hasFollowingRepeatedValue && !hasAnotherSharedValue) {
+      const wrapped = value.slice(wrapperStart);
+      const unwrapped = unwrapPairedUrlWrapper(wrapped, text, start + wrapperStart);
+      if (
+        unwrapped.value !== wrapped &&
+        isSupportedWrappedSchemelessUrlCandidate(unwrapped.value)
+      ) {
+        candidates.push(unwrapped);
+        break;
+      }
+    }
+
+    let openingEnd = wrapperStart + 1;
+    if (!isPairedWrapper) {
+      while (openingEnd < value.length && value[openingEnd] === openingCharacter) {
+        openingEnd += 1;
+      }
+    }
+    const openingWrapper = value.slice(wrapperStart, openingEnd);
+    const closingWrapper = isPairedWrapper
+      ? (URL_WRAPPER_PAIRS.get(openingCharacter) ?? '')
+      : openingWrapper;
+    let closingStart = isPairedWrapper
+      ? pairedClosingStart
+      : value.indexOf(closingWrapper, openingEnd);
+    while (closingStart >= 0) {
+      const escapedDelimiter = !isPairedWrapper && isEscapedUrlDelimiter(value, closingStart);
+      const nextCharacter = value[closingStart + closingWrapper.length] ?? '';
+      const internalApostrophe =
+        openingCharacter === "'" && /[\p{L}\p{N}%_\\/?#-]/u.test(nextCharacter);
+      if (!escapedDelimiter && !internalApostrophe) {
+        break;
+      }
+      closingStart = value.indexOf(closingWrapper, closingStart + closingWrapper.length);
+    }
+    if (closingStart < 0) {
+      const wrapperPrefixLength = wrapperPrefixEnd - wrapperStart;
+      offset =
+        wrapperPrefixLength > MAX_WRAPPER_PREFIX_DESCENT ? wrapperPrefixEnd : wrapperStart + 1;
+      continue;
+    }
+    // A closer beyond another same-type opener does not safely bound the outer
+    // token. Continue from the nested opener instead of materializing both spans.
+    if (isPairedWrapper && nextPairedOpeningStart >= 0 && nextPairedOpeningStart < closingStart) {
+      offset = repeatedWrapperEnd;
+      continue;
+    }
+
+    const wrappedEnd = closingStart + closingWrapper.length;
+    const boundedWrapper = value.slice(wrapperStart, wrappedEnd);
+    const localBoundedCandidate = unwrapPairedUrlWrapper(boundedWrapper, boundedWrapper, 0);
+    const boundedCandidate = {
+      value: localBoundedCandidate.value,
+      start: start + wrapperStart + localBoundedCandidate.start,
+      end: start + wrapperStart + localBoundedCandidate.end,
+    };
+    const isSupportedBoundedCandidate =
+      boundedCandidate.value !== boundedWrapper &&
+      isSupportedWrappedSchemelessUrlCandidate(boundedCandidate.value);
+    if (isSupportedBoundedCandidate) {
+      candidates.push(boundedCandidate);
+    } else if (
+      boundedCandidate.value !== boundedWrapper &&
+      hasPotentialWrappedSchemelessUrlStart(boundedCandidate.value) &&
+      isDisruptedSchemelessUrlCandidate(boundedCandidate.value, true)
+    ) {
+      candidates.push({
+        value: boundedWrapper,
+        start: start + wrapperStart,
+        end: start + wrappedEnd,
+      });
+    }
+    if (isSharedDelimiter) {
+      offset = closingStart;
+    } else if (isPairedWrapper && !isSupportedBoundedCandidate) {
+      const wrapperPrefixLength = wrapperPrefixEnd - wrapperStart;
+      offset =
+        wrapperPrefixLength > MAX_WRAPPER_PREFIX_DESCENT ? wrapperPrefixEnd : repeatedWrapperEnd;
+    } else {
+      offset = wrappedEnd;
+    }
+  }
+
+  return candidates;
+}
+
+const SCHEMELESS_ASSIGNMENT_KEY_RE = /^[\p{L}_:][\p{L}\p{N}_.:-]*$/u;
+const SCHEMELESS_ASSIGNMENT_EXCLUDED_DELIMITER_RE = /[<>"{}|^`]/;
+
+type HtmlStartTagScanState = 'outside' | 'tag-name-start' | 'tag-name' | 'inside' | 'invalid';
+
+function createHtmlStartTagTracker(text: string): (position: number) => boolean {
+  let offset = 0;
+  let state: HtmlStartTagScanState = 'outside';
+
+  return (position: number): boolean => {
+    while (offset < position) {
+      const character = text[offset];
+      if (character === '<') {
+        state = 'tag-name-start';
+      } else if (character === '>') {
+        state = 'outside';
+      } else if (state === 'tag-name-start') {
+        state = isAsciiSchemeStart(character) ? 'tag-name' : 'invalid';
+      } else if (state === 'tag-name') {
+        if (isAsciiAlphanumeric(character) || character === ':' || character === '-') {
+          // Continue scanning the tag name.
+        } else {
+          state = /\s/u.test(character) ? 'inside' : 'invalid';
+        }
+      }
+      offset += 1;
+    }
+
+    return state === 'inside';
+  };
+}
+
+function findAssignedSchemelessUrlCandidate(
+  value: string,
+  start: number,
+  isInsideHtmlStartTag: boolean
+): UrlCandidate | null {
+  const assignment = value.indexOf('=');
+  if (assignment <= 0 || !SCHEMELESS_ASSIGNMENT_KEY_RE.test(value.slice(0, assignment))) {
+    return null;
+  }
+
+  const candidateStart = assignment + 1;
+  const remainder = value.slice(candidateStart);
+  const candidate =
+    isInsideHtmlStartTag && remainder.endsWith('>') ? remainder.slice(0, -1) : remainder;
+  if (SCHEMELESS_ASSIGNMENT_EXCLUDED_DELIMITER_RE.test(candidate)) {
+    return null;
+  }
+  if (!isSupportedWrappedSchemelessUrlCandidate(candidate)) {
+    return null;
+  }
+
+  const absoluteStart = start + candidateStart;
+  return {
+    value: candidate,
+    start: absoluteStart,
+    end: absoluteStart + candidate.length,
+  };
+}
+
+function detectExclusiveSchemelessUrls(text: string): UrlCandidate[] {
+  const candidates: UrlCandidate[] = [];
+  const isInsideHtmlStartTagAt = createHtmlStartTagTracker(text);
+  for (const result of text.matchAll(/\S+/gu)) {
+    const value = result[0];
+    const isInsideHtmlStartTag = isInsideHtmlStartTagAt(result.index);
+    const explicitUrlPrefix = findDetectedUrlPrefixInToken(value);
+    if (explicitUrlPrefix) {
+      let firstWrapper = 0;
+      while (firstWrapper < value.length && !isUrlWrapperOpeningCharacter(value[firstWrapper])) {
+        firstWrapper += 1;
+      }
+      if (firstWrapper === value.length || explicitUrlPrefix.index <= firstWrapper) {
+        continue;
+      }
+    }
+    const wrappedCandidates = findWrappedSchemelessUrlCandidates(value, text, result.index);
+    if (wrappedCandidates.length > 0) {
+      candidates.push(...wrappedCandidates);
+      continue;
+    }
+    const assignedCandidate = findAssignedSchemelessUrlCandidate(
+      value,
+      result.index,
+      isInsideHtmlStartTag
+    );
+    if (assignedCandidate) {
+      candidates.push(assignedCandidate);
+      continue;
+    }
+    if (isDisruptedSchemelessUrlCandidate(value)) {
+      candidates.push({ value, start: result.index, end: result.index + value.length });
+    }
+  }
+  return candidates;
+}
+
+function detectAmbiguousUrls(text: string): UrlCandidate[] {
+  if (!ASCII_URL_CONTROL_RE.test(text)) {
+    return [];
+  }
+
+  const entireInputCandidate = detectEntireInputAmbiguousUrl(text);
+  if (entireInputCandidate) {
+    return [entireInputCandidate];
+  }
+
+  const candidates: UrlCandidate[] = [];
+  const atSignPositions: number[] = [];
+  const controlPositions: number[] = [];
+  for (let index = text.indexOf('@'); index >= 0; index = text.indexOf('@', index + 1)) {
+    atSignPositions.push(index);
+  }
+  for (const result of text.matchAll(/[\t\n\r]/g)) {
+    controlPositions.push(result.index);
+  }
+  const normalizedPrefixText = text.replace(/[\t\n\r]/g, '');
+  const hasControlNormalizedPrefix = findDetectedUrlPrefixInToken(normalizedPrefixText) !== null;
+  CONTROL_TOLERANT_URL_CANDIDATE_RE.lastIndex = 0;
+  const matches = hasControlNormalizedPrefix
+    ? [...text.matchAll(CONTROL_TOLERANT_URL_CANDIDATE_RE)].filter((result) => {
+        if (!hasStandaloneSchemeStart(text, result.index)) {
+          return false;
+        }
+        const explicitAuthorityBoundary = result[0].search(EXPLICIT_AUTHORITY_URL_LINE_BOUNDARY_RE);
+        if (explicitAuthorityBoundary <= 0) {
+          return true;
+        }
+
+        const precedingCandidate = cleanAmbiguousUrlCandidate(
+          result[0].slice(0, explicitAuthorityBoundary)
+        );
+        return !isSupportedSchemelessUrlCandidate(precedingCandidate, true);
+      })
+    : [];
+  const explicitAuthorityPositions = matches
+    .filter((result) => /^[a-z][a-z0-9+.-]*:\/\//i.test(result[0].replace(/[\t\n\r]/g, '')))
+    .map((result) => result.index);
+
+  const rawSchemelessCandidates: UrlCandidate[] = [];
+  const seenSchemelessRanges = new Set<string>();
+  for (const {
+    pattern,
+    shouldScan,
+    shouldInclude,
+    allowNumericLeadingFinalLabel,
+  } of SCHEMELESS_CANDIDATE_PATTERNS) {
+    if (!shouldScan(text)) {
+      continue;
+    }
+    pattern.lastIndex = 0;
+    for (const result of text.matchAll(pattern)) {
+      const value = result[0];
+      if (shouldInclude && !shouldInclude(value)) {
+        continue;
+      }
+      if (!isSupportedSchemelessUrlCandidate(value, allowNumericLeadingFinalLabel)) {
+        continue;
+      }
+      const start = result.index;
+      const end = start + value.length;
+      const rangeKey = `${start}:${end}`;
+      if (value && !seenSchemelessRanges.has(rangeKey)) {
+        rawSchemelessCandidates.push({ value, start, end });
+        seenSchemelessRanges.add(rangeKey);
+      }
+    }
+  }
+  rawSchemelessCandidates.sort((left, right) => left.start - right.start);
+
+  const schemelessBridgeOwners: UrlCandidate[] = [];
+  let schemeMatchIndex = 0;
+  for (const candidate of rawSchemelessCandidates) {
+    while (
+      schemeMatchIndex < matches.length &&
+      matches[schemeMatchIndex].index + matches[schemeMatchIndex][0].length <= candidate.start
+    ) {
+      schemeMatchIndex += 1;
+    }
+    const containingSchemeMatch = matches[schemeMatchIndex];
+    if (
+      containingSchemeMatch &&
+      containingSchemeMatch.index <= candidate.start &&
+      candidate.end <= containingSchemeMatch.index + containingSchemeMatch[0].length
+    ) {
+      continue;
+    }
+    schemelessBridgeOwners.push(candidate);
+  }
+
+  const schemeBridgeOwnerPositions = matches.map((result) => result.index);
+  const allBridgeOwnerPositions = [
+    ...schemeBridgeOwnerPositions,
+    ...schemelessBridgeOwners.map((candidate) => candidate.start),
+  ].sort((left, right) => left - right);
+  const detectWhitespaceBridge = (
+    start: number,
+    controlSearchStart: number,
+    ownerPositions: number[]
+  ): UrlCandidate | null => {
+    const control = findFirstPositionAtOrAfter(controlPositions, controlSearchStart);
+    if (control === null) {
+      return null;
+    }
+    const atSign = findFirstPositionAtOrAfter(atSignPositions, control + 1);
+    if (atSign === null) {
+      return null;
+    }
+
+    // Let the closest URL candidate before the control own this bridge. This
+    // prevents repeated materialization of the same long span.
+    const nextOwner = findFirstPositionAtOrAfter(ownerPositions, start + 1);
+    if (nextOwner !== null && nextOwner <= control) {
+      return null;
+    }
+
+    // A slash-less scheme-like token before `@` can still become userinfo in
+    // the original URL. Preserve every explicit `scheme://` as a boundary.
+    const explicitAuthority = findFirstPositionAtOrAfter(explicitAuthorityPositions, control + 1);
+    if (explicitAuthority !== null && explicitAuthority <= atSign) {
+      return null;
+    }
+
+    const nextScheme = findFirstPositionAtOrAfter(schemeBridgeOwnerPositions, start + 1);
+    const bridgeLimit = nextScheme !== null && atSign < nextScheme ? nextScheme : text.length;
+    let bridgedEnd = atSign + 1;
+    while (bridgedEnd < bridgeLimit && !NON_CONTROL_WHITESPACE_RE.test(text[bridgedEnd])) {
+      bridgedEnd += 1;
+    }
+    if (control >= bridgedEnd) {
+      return null;
+    }
+
+    const value = cleanAmbiguousUrlCandidate(text.slice(start, bridgedEnd));
+    if (!hasInternalUrlControl(value)) {
+      return null;
+    }
+
+    return { value, start, end: start + value.length };
+  };
+
+  for (const result of matches) {
+    const rawMatch = result[0];
+    const start = result.index;
+    const value = cleanAmbiguousUrlCandidate(rawMatch);
+    if (!value) {
+      continue;
+    }
+
+    if (!hasInternalUrlControl(value)) {
+      const bridgedCandidate = detectWhitespaceBridge(start, start, schemeBridgeOwnerPositions);
+      if (bridgedCandidate) {
+        candidates.push(bridgedCandidate);
+      }
+      continue;
+    }
+
+    const end = start + value.length;
+    candidates.push({ value, start, end });
+  }
+
+  for (const candidate of schemelessBridgeOwners) {
+    const bridgedCandidate = detectWhitespaceBridge(
+      candidate.start,
+      candidate.end,
+      allBridgeOwnerPositions
+    );
+    if (bridgedCandidate) {
+      candidates.push(bridgedCandidate);
+    }
+  }
+
+  return mergeAmbiguousUrlCandidates(text, [
+    ...candidates,
+    ...detectControlObfuscatedSchemeRelativeUrls(text),
+    ...detectControlObfuscatedGenericSchemes(text),
+    ...detectAmbiguousSchemelessUrls(text),
+  ]);
+}
 
 function normalizeAllowedSchemes(value: unknown): Set<string> {
   if (value === undefined || value === null) {
@@ -95,7 +1762,7 @@ function ipToInt(ip: string): number {
 }
 
 function extractHostCandidate(url: string): string | null {
-  if (!url.includes('://')) {
+  if (!hasExplicitAuthorityScheme(url)) {
     return null;
   }
 
@@ -106,7 +1773,7 @@ function extractHostCandidate(url: string): string | null {
 
   const hostAndRest = rest.split(/[/?#]/, 1)[0];
   const withoutCreds = hostAndRest.includes('@')
-    ? hostAndRest.split('@').pop() ?? ''
+    ? (hostAndRest.split('@').pop() ?? '')
     : hostAndRest;
   if (!withoutCreds) {
     return null;
@@ -123,66 +1790,729 @@ function extractHostCandidate(url: string): string | null {
   return withoutCreds.split(':', 1)[0];
 }
 
+function isUrlLikeSpecialSchemeCandidate(value: string): boolean {
+  const colonIndex = value.indexOf(':');
+  if (colonIndex < 0) {
+    return false;
+  }
+
+  const scheme = value.slice(0, colonIndex).toLowerCase();
+  const payload = value.slice(colonIndex + 1);
+
+  try {
+    const hostname = normalizeHostnameForComparison(new URL(value).hostname);
+    return (
+      scheme === 'file' ||
+      /[\\/?#]/.test(payload) ||
+      hostname === 'localhost' ||
+      hostname.includes('.') ||
+      isIpv4Address(hostname) ||
+      (hostname.startsWith('[') && hostname.endsWith(']'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasExcludedDelimiterInExplicitAuthority(value: string): boolean {
+  const colonIndex = value.indexOf(':');
+  if (colonIndex < 0) {
+    return false;
+  }
+
+  try {
+    new URL(value);
+  } catch {
+    return false;
+  }
+
+  const scheme = value.slice(0, colonIndex).toLowerCase();
+  const payload = value.slice(colonIndex + 1);
+  const isSpecialScheme = AUTHORITY_SCHEMES.includes(scheme);
+  let authorityStart: number;
+  if (isSpecialScheme) {
+    authorityStart = 0;
+    while (authorityStart < payload.length && /[\\/]/.test(payload[authorityStart])) {
+      authorityStart += 1;
+    }
+  } else if (payload.startsWith('//')) {
+    authorityStart = 2;
+  } else {
+    return false;
+  }
+  const authorityRemainder = payload.slice(authorityStart);
+  const authorityEnd = authorityRemainder.search(isSpecialScheme ? /[\\/?#]/ : /[/?#]/);
+  const rawAuthority =
+    authorityEnd < 0 ? authorityRemainder : authorityRemainder.slice(0, authorityEnd);
+  return /[<>"{}|\\^\x60\x5b\x5d]/.test(rawAuthority);
+}
+
+function hasExcludedDelimiterInSchemelessAuthority(value: string): boolean {
+  try {
+    new URL(`http://${value}`);
+  } catch {
+    return false;
+  }
+
+  const authorityEnd = value.search(/[\\/?#]/);
+  const rawAuthority = authorityEnd < 0 ? value : value.slice(0, authorityEnd);
+  return (
+    SCHEMELESS_DOMAIN_SEPARATOR_RE.test(rawAuthority) &&
+    /[<>"{}|\\^\x60\x5b\x5d]/.test(rawAuthority)
+  );
+}
+
+function hasParsedUserinfo(value: string): boolean {
+  try {
+    const parsedUrl = /^[\\/]{2}/.test(value)
+      ? new URL(value, SCHEME_RELATIVE_BASE_URL)
+      : new URL(value);
+    return Boolean(parsedUrl.username || parsedUrl.password);
+  } catch {
+    return false;
+  }
+}
+
+function isParsableUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasParsedUserinfoAtFinalSeparator(
+  value: string,
+  parseMode: UserinfoBridgeOwner['parseMode']
+): boolean {
+  try {
+    const parsedUrl =
+      parseMode === 'scheme-less'
+        ? new URL(`http://${value}`)
+        : /^[\\/]{2}/.test(value)
+          ? new URL(value, SCHEME_RELATIVE_BASE_URL)
+          : new URL(value);
+    if (!parsedUrl.username && !parsedUrl.password) {
+      return false;
+    }
+
+    const finalSeparator = value.lastIndexOf('@');
+    const authorityTail = value.slice(finalSeparator + 1);
+    const parsedTail = new URL(`${parsedUrl.protocol}//${authorityTail}`);
+    return parsedUrl.host.toLowerCase() === parsedTail.host.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+function detectWhitespaceBridgedUserinfoUrls(text: string): WhitespaceBridgedUserinfoCandidate[] {
+  if (!text.includes('@') || !NON_CONTROL_WHITESPACE_RE.test(text)) {
+    return [];
+  }
+
+  const rawOwners: UserinfoBridgeOwner[] = [];
+  const seenRanges = new Set<string>();
+
+  const addOwner = (
+    value: string,
+    start: number,
+    parseMode: UserinfoBridgeOwner['parseMode']
+  ): void => {
+    const end = start + value.length;
+    const rangeKey = `${start}:${end}`;
+    if (!seenRanges.has(rangeKey)) {
+      rawOwners.push({ value, start, end, parseMode });
+      seenRanges.add(rangeKey);
+    }
+  };
+
+  if (findDetectedUrlPrefixInToken(text)) {
+    WHITESPACE_BRIDGE_EXPLICIT_OWNER_RE.lastIndex = 0;
+    for (const result of text.matchAll(WHITESPACE_BRIDGE_EXPLICIT_OWNER_RE)) {
+      if (!hasStandaloneSchemeStart(text, result.index)) {
+        continue;
+      }
+      addOwner(result[0], result.index, 'explicit');
+    }
+  }
+
+  WHITESPACE_BRIDGE_SCHEME_RELATIVE_OWNER_RE.lastIndex = 0;
+  for (const result of text.matchAll(WHITESPACE_BRIDGE_SCHEME_RELATIVE_OWNER_RE)) {
+    addOwner(result[0], result.index, 'scheme-relative');
+  }
+
+  // Userinfo candidates begin after the bridge owner and would incorrectly
+  // displace it, so only host-based patterns participate in owner selection.
+  for (const { pattern, shouldScan, shouldInclude } of SCHEMELESS_CANDIDATE_PATTERNS.slice(0, -1)) {
+    if (!shouldScan(text)) {
+      continue;
+    }
+    pattern.lastIndex = 0;
+    for (const result of text.matchAll(pattern)) {
+      const value = result[0];
+      if (shouldInclude && !shouldInclude(value)) {
+        continue;
+      }
+      if (!isSupportedSchemelessUrlCandidate(value, true)) {
+        continue;
+      }
+      addOwner(value, result.index, 'scheme-less');
+    }
+  }
+
+  rawOwners.sort((left, right) => left.start - right.start || right.end - left.end);
+  const owners: UserinfoBridgeOwner[] = [];
+  for (const owner of rawOwners) {
+    const previous = owners[owners.length - 1];
+    if (!previous || owner.start >= previous.end) {
+      owners.push(owner);
+    }
+  }
+
+  const atSignPositions: number[] = [];
+  for (let index = text.indexOf('@'); index >= 0; index = text.indexOf('@', index + 1)) {
+    atSignPositions.push(index);
+  }
+  const structuralOwnerPositions = owners
+    .filter((owner) => owner.parseMode !== 'scheme-less')
+    .map((owner) => owner.start);
+
+  const bridgedCandidates: WhitespaceBridgedUserinfoCandidate[] = [];
+  for (let ownerIndex = 0; ownerIndex < owners.length; ownerIndex += 1) {
+    const owner = owners[ownerIndex];
+    const nextStructuralOwner = findFirstPositionAtOrAfter(
+      structuralOwnerPositions,
+      owner.start + 1
+    );
+    // WHATWG treats the final `@` in an authority as the host separator. Use
+    // the final separator owned by this candidate so an earlier, allowlisted
+    // intermediate host cannot truncate validation. Explicit and relative
+    // owners retain their scheme through the next structural URL boundary.
+    // Scheme-less owners stop at the next owner so only the closest one scans
+    // a given separator and large host lists remain linear.
+    const nextOwner = owners[ownerIndex + 1];
+    const boundary =
+      owner.parseMode === 'scheme-less'
+        ? (nextOwner?.start ?? text.length)
+        : (nextStructuralOwner ?? text.length);
+    const atSign = findLastPositionBefore(atSignPositions, boundary);
+    if (atSign === null || atSign < owner.end) {
+      continue;
+    }
+
+    const bridge = text.slice(owner.end, atSign);
+    if (ASCII_URL_CONTROL_RE.test(bridge) || !NON_CONTROL_WHITESPACE_RE.test(bridge)) {
+      continue;
+    }
+
+    let end = atSign + 1;
+    while (end < text.length && !URL_WHITESPACE_RE.test(text[end])) {
+      end += 1;
+    }
+    const value = text.slice(owner.start, end);
+    if (!hasParsedUserinfoAtFinalSeparator(value, owner.parseMode)) {
+      continue;
+    }
+
+    const ordinaryEmail = findOrdinaryEmailRangeAt(text, atSign);
+    bridgedCandidates.push({
+      value,
+      start: owner.start,
+      end,
+      // A later ordinary email address can parse as this URL's final host.
+      // Preserve the source URL so the bridge cannot hide its validation.
+      independentOwner: ordinaryEmail
+        ? { value: owner.value, start: owner.start, end: owner.end }
+        : undefined,
+    });
+  }
+
+  bridgedCandidates.sort((left, right) => left.start - right.start || right.end - left.end);
+  const disjointCandidates: WhitespaceBridgedUserinfoCandidate[] = [];
+  for (const candidate of bridgedCandidates) {
+    const previous = disjointCandidates[disjointCandidates.length - 1];
+    if (!previous || candidate.start >= previous.end) {
+      disjointCandidates.push(candidate);
+    } else if (candidate.end > previous.end) {
+      // Overlapping scheme-less owners can hand the same authority forward
+      // through multiple `@` separators. Keep the candidate that reaches the
+      // final parsed host; structural candidates already span that full range.
+      disjointCandidates[disjointCandidates.length - 1] = candidate;
+    }
+  }
+  return disjointCandidates;
+}
+
 /**
  * Detect URLs in text using robust regex patterns.
  */
 function detectUrls(text: string): string[] {
-  // Pattern for cleaning trailing punctuation (] must be escaped)
-  const PUNCTUATION_CLEANUP = /[.,;:!?)\\]]+$/;
+  const ambiguousUrls = detectAmbiguousUrls(text);
+  const detectedUrls: string[] = ambiguousUrls.map((candidate) => candidate.value);
+  const ordinaryEmailLocalPartRanges: Array<{ start: number; end: number }> = [];
+  for (
+    let separator = text.indexOf('@');
+    separator >= 0;
+    separator = text.indexOf('@', separator + 1)
+  ) {
+    const ordinaryEmail = findOrdinaryEmailRangeAt(text, separator);
+    if (ordinaryEmail) {
+      ordinaryEmailLocalPartRanges.push({
+        start: ordinaryEmail.start,
+        end: ordinaryEmail.separator,
+      });
+    }
+  }
+  const startsInsideOrdinaryEmailLocalPart = (start: number): boolean => {
+    let low = 0;
+    let high = ordinaryEmailLocalPartRanges.length - 1;
+    let candidateIndex = -1;
 
-  const detectedUrls: string[] = [];
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      if (ordinaryEmailLocalPartRanges[middle].start <= start) {
+        candidateIndex = middle;
+        low = middle + 1;
+      } else {
+        high = middle - 1;
+      }
+    }
+
+    return candidateIndex >= 0 && start < ordinaryEmailLocalPartRanges[candidateIndex].end;
+  };
+  const overlapsOrdinaryEmailLocalPart = (start: number, end: number): boolean => {
+    let low = 0;
+    let high = ordinaryEmailLocalPartRanges.length;
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (ordinaryEmailLocalPartRanges[middle].end <= start) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+
+    return (
+      low < ordinaryEmailLocalPartRanges.length && ordinaryEmailLocalPartRanges[low].start < end
+    );
+  };
+  const isInsideAmbiguousUrl = (start: number, end: number): boolean => {
+    let low = 0;
+    let high = ambiguousUrls.length - 1;
+    let candidateIndex = -1;
+
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      if (ambiguousUrls[middle].start <= start) {
+        candidateIndex = middle;
+        low = middle + 1;
+      } else {
+        high = middle - 1;
+      }
+    }
+
+    return candidateIndex >= 0 && end <= ambiguousUrls[candidateIndex].end;
+  };
+  const exclusiveSchemelessUrls = detectExclusiveSchemelessUrls(text).filter(
+    (candidate) =>
+      !isInsideAmbiguousUrl(candidate.start, candidate.end) &&
+      !overlapsOrdinaryEmailLocalPart(candidate.start, candidate.end)
+  );
+  detectedUrls.push(...exclusiveSchemelessUrls.map((candidate) => candidate.value));
 
   // Pattern 1: URLs with schemes (highest priority)
-  const schemePatterns = [
-    /https?:\/\/[^\s<>"{}|\\^`[\]]+/gi,
-    /ftp:\/\/[^\s<>"{}|\\^`[\]]+/gi,
-    /data:[^\s<>"{}|\\^`[\]]+/gi,
-    /javascript:[^\s<>"{}|\\^`[\]]+/gi,
-    /vbscript:[^\s<>"{}|\\^`[\]]+/gi,
+  const nestedAuthorityStartPattern =
+    `(?:${AUTHORITY_SCHEMES.join('|')}):|` + `${GENERIC_SCHEME_PATTERN}:\\/\\/|` + `[/\\\\]{2}`;
+  const whitespaceBridgeContentPattern = `(?:(?!${nestedAuthorityStartPattern})[^\\t\\n\\r@])*`;
+  const whitespaceBridgedExplicitUserinfoPattern = new RegExp(
+    `(?<![a-z0-9])(?:` +
+      `(?:${AUTHORITY_SCHEMES.join('|')}):|${GENERIC_SCHEME_PATTERN}:\\/\\/` +
+      `)${whitespaceBridgeContentPattern}[^\\S\\t\\n\\r]` +
+      `${whitespaceBridgeContentPattern}@[^\\s]+`,
+    'gi'
+  );
+  const whitespaceBridgedSchemeRelativeUserinfoPattern = new RegExp(
+    `(?<![:/\\\\])[/\\\\]{2,}` +
+      `${whitespaceBridgeContentPattern}[^\\S\\t\\n\\r]` +
+      `${whitespaceBridgeContentPattern}@[^\\s]+`,
+    'gi'
+  );
+  const delimiterBridgedUserinfoPattern = new RegExp(
+    `(?<![a-z0-9])(?:` +
+      `(?:${AUTHORITY_SCHEMES.join('|')}):|${GENERIC_SCHEME_PATTERN}:\\/\\/` +
+      `)(?=[^\\s<>"{}|\\\\^\\x60\\[\\]@]*` +
+      `[<>"{}|\\\\^\\x60\\[\\]][^\\s@]*@)[^\\s]+`,
+    'gi'
+  );
+  const delimiterBridgedStructuralPattern = new RegExp(
+    `(?<![a-z0-9])(?:` +
+      `(?:${AUTHORITY_SCHEMES.join('|')}):|${GENERIC_SCHEME_PATTERN}:\\/\\/` +
+      `)(?=[^\\s]*?[<>"{}|\\\\^\\x60\\[\\]][\\/\\\\?#@])[^\\s]+`,
+    'gi'
+  );
+  const excludedAuthoritySpecialSchemePattern = new RegExp(
+    `(?<![a-z0-9])(?:${AUTHORITY_SCHEMES.join('|')}):` +
+      `(?=[^\\s]*?[<>"{}|\\\\^\\x60\\[\\]])[^\\s]+`,
+    'gi'
+  );
+  const excludedAuthorityGenericSchemePattern = new RegExp(
+    `(?<![a-z0-9])${GENERIC_SCHEME_PATTERN}:\\/\\/` + `(?=[^\\s]*?[<>"{}|\\\\^\\x60\\[\\]])[^\\s]+`,
+    'gi'
+  );
+  const excludedAuthoritySchemelessPattern = new RegExp(
+    `(?<![\\p{L}\\p{N}%_.\\-\\u3002\\uff0e\\uff61])` +
+      `(?=[^\\s]*${SCHEMELESS_DOMAIN_SEPARATOR_PATTERN})` +
+      `(?=[^\\s]*[<>"{}|\\\\^\\x60\\[\\]])[\\p{L}\\p{N}][^\\s]+`,
+    'giu'
+  );
+  const specialSchemePattern = /(?<![a-z0-9])(?:https?|ftp|wss?|file):[^\s<>"{}|^`]+/gi;
+  const schemePatterns: Array<{
+    pattern: RegExp;
+    ownsNestedCandidates: boolean;
+    ownsCleanedRange?: boolean;
+    requiresExplicitPrefix?: boolean;
+    shouldScan?: (value: string) => boolean;
+    shouldInclude?: (value: string) => boolean;
+    clean?: (value: string, text: string, start: number) => string;
+  }> = [
+    {
+      pattern: whitespaceBridgedExplicitUserinfoPattern,
+      ownsNestedCandidates: true,
+      requiresExplicitPrefix: true,
+      shouldScan: (value) => value.includes('@') && NON_CONTROL_WHITESPACE_RE.test(value),
+      shouldInclude: hasParsedUserinfo,
+    },
+    {
+      pattern: whitespaceBridgedSchemeRelativeUserinfoPattern,
+      ownsNestedCandidates: true,
+      shouldInclude: hasParsedUserinfo,
+    },
+    {
+      pattern: excludedAuthoritySpecialSchemePattern,
+      ownsNestedCandidates: true,
+      requiresExplicitPrefix: true,
+      shouldScan: hasExcludedUrlDelimiter,
+      shouldInclude: hasExcludedDelimiterInExplicitAuthority,
+      clean: cleanExcludedAuthorityPairedWrapper,
+      ownsCleanedRange: true,
+    },
+    {
+      pattern: excludedAuthorityGenericSchemePattern,
+      ownsNestedCandidates: true,
+      requiresExplicitPrefix: true,
+      shouldScan: hasExcludedUrlDelimiter,
+      shouldInclude: hasExcludedDelimiterInExplicitAuthority,
+      clean: cleanExcludedAuthorityPairedWrapper,
+      ownsCleanedRange: true,
+    },
+    {
+      pattern: SCHEME_RELATIVE_URL_RE,
+      ownsNestedCandidates: true,
+      shouldInclude: isSupportedSchemeRelativeUrlCandidate,
+      clean: cleanTrailingAuthorityProsePunctuation,
+    },
+    {
+      pattern: excludedAuthoritySchemelessPattern,
+      ownsNestedCandidates: true,
+      shouldScan: (value) => hasDomainSeparator(value) && hasExcludedUrlDelimiter(value),
+      shouldInclude: hasExcludedDelimiterInSchemelessAuthority,
+      clean: cleanExcludedAuthorityPairedWrapper,
+      ownsCleanedRange: true,
+    },
+    {
+      pattern: delimiterBridgedUserinfoPattern,
+      ownsNestedCandidates: true,
+      requiresExplicitPrefix: true,
+      shouldScan: (value) => value.includes('@') && hasExcludedUrlDelimiter(value),
+      shouldInclude: hasParsedUserinfo,
+    },
+    {
+      pattern: delimiterBridgedStructuralPattern,
+      ownsNestedCandidates: true,
+      requiresExplicitPrefix: true,
+      shouldScan: hasExcludedUrlDelimiter,
+      shouldInclude: isParsableUrl,
+    },
+    {
+      pattern: specialSchemePattern,
+      ownsNestedCandidates: true,
+      requiresExplicitPrefix: true,
+      shouldInclude: isUrlLikeSpecialSchemeCandidate,
+      clean: cleanTrailingAuthorityProsePunctuation,
+    },
+    {
+      pattern: /(?<![a-z0-9])[a-z][a-z0-9+.-]*:\/\/[^\s<>"{}|\\^`[\]]+/gi,
+      ownsNestedCandidates: true,
+      requiresExplicitPrefix: true,
+      clean: cleanTrailingAuthorityProsePunctuation,
+    },
+    {
+      pattern: /(?<![a-z0-9])(?:data|javascript|vbscript|mailto):(?=[<>"{}|\\^`[\]])[^\s]+/gi,
+      ownsNestedCandidates: true,
+      requiresExplicitPrefix: true,
+    },
+    {
+      pattern: /(?<![a-z0-9])(?:data|javascript|vbscript|mailto):(?=[\t\n\r])/gi,
+      ownsNestedCandidates: false,
+      requiresExplicitPrefix: true,
+    },
+    {
+      pattern: /(?<![a-z0-9])data:[^\s<>"{}|\\^`[\]]+/gi,
+      ownsNestedCandidates: false,
+      requiresExplicitPrefix: true,
+    },
+    {
+      pattern: /(?<![a-z0-9])javascript:[^\s<>"{}|\\^`[\]]+/gi,
+      ownsNestedCandidates: false,
+      requiresExplicitPrefix: true,
+    },
+    {
+      pattern: /(?<![a-z0-9])vbscript:[^\s<>"{}|\\^`[\]]+/gi,
+      ownsNestedCandidates: false,
+      requiresExplicitPrefix: true,
+    },
+    {
+      pattern: /(?<![a-z0-9])mailto:[^\s<>"{}|\\^`[\]]+/gi,
+      ownsNestedCandidates: true,
+      requiresExplicitPrefix: true,
+    },
   ];
 
   const schemeUrls = new Set<string>();
-  for (const pattern of schemePatterns) {
-    const matches = text.match(pattern) || [];
-    for (let match of matches) {
-      // Clean trailing punctuation
-      match = match.replace(PUNCTUATION_CLEANUP, '');
+  const explicitUrlPrefixInText = findDetectedUrlPrefixInToken(text);
+  const hasExplicitUrlCandidate =
+    explicitUrlPrefixInText !== null && explicitUrlPrefixInText.end < text.length;
+  const exclusiveSchemeRanges: Array<{ start: number; end: number }> = exclusiveSchemelessUrls.map(
+    ({ start, end }) => ({ start, end })
+  );
+  const isInsideExclusiveSchemeUrl = (start: number, end: number): boolean => {
+    let low = 0;
+    let high = exclusiveSchemeRanges.length - 1;
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      const range = exclusiveSchemeRanges[middle];
+      if (start < range.start) {
+        high = middle - 1;
+      } else if (start >= range.end) {
+        low = middle + 1;
+      } else {
+        return end <= range.end;
+      }
+    }
+    return false;
+  };
+  const overlapsExclusiveUrl = (start: number, end: number): boolean => {
+    let low = 0;
+    let high = exclusiveSchemeRanges.length;
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (exclusiveSchemeRanges[middle].end <= start) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return low < exclusiveSchemeRanges.length && exclusiveSchemeRanges[low].start < end;
+  };
+
+  for (const candidate of detectWhitespaceBridgedUserinfoUrls(text)) {
+    if (isInsideAmbiguousUrl(candidate.start, candidate.end)) {
+      continue;
+    }
+    if (
+      candidate.independentOwner &&
+      !isInsideAmbiguousUrl(candidate.independentOwner.start, candidate.independentOwner.end)
+    ) {
+      detectedUrls.push(candidate.independentOwner.value);
+      exclusiveSchemeRanges.push({
+        start: candidate.independentOwner.start,
+        end: candidate.independentOwner.end,
+      });
+    }
+    detectedUrls.push(candidate.value);
+    exclusiveSchemeRanges.push({ start: candidate.start, end: candidate.end });
+  }
+  exclusiveSchemeRanges.sort((left, right) => left.start - right.start);
+
+  for (const {
+    pattern,
+    ownsNestedCandidates,
+    ownsCleanedRange,
+    requiresExplicitPrefix,
+    shouldScan,
+    shouldInclude,
+    clean,
+  } of schemePatterns) {
+    if (requiresExplicitPrefix && !hasExplicitUrlCandidate) {
+      continue;
+    }
+    if (shouldScan && !shouldScan(text)) {
+      continue;
+    }
+    for (const result of text.matchAll(pattern)) {
+      const rawMatch = result[0];
+      if (isAsciiSchemeStart(rawMatch[0]) && !hasStandaloneSchemeStart(text, result.index)) {
+        continue;
+      }
+      if (shouldInclude && !shouldInclude(rawMatch)) {
+        continue;
+      }
+      const match = clean ? clean(rawMatch, text, result.index) : rawMatch;
       if (match) {
+        const start = result.index;
+        const end = start + (ownsCleanedRange ? match.length : rawMatch.length);
+        if (isInsideAmbiguousUrl(start, end)) {
+          continue;
+        }
+        if (isInsideExclusiveSchemeUrl(start, end)) {
+          continue;
+        }
+        const hasExplicitUrlPrefix = /^[a-z][a-z0-9+.-]*:/i.test(match) || /^[\\/]{2}/.test(match);
+        if (!hasExplicitUrlPrefix && overlapsExclusiveUrl(start, end)) {
+          continue;
+        }
         detectedUrls.push(match);
+        if (ownsNestedCandidates) {
+          exclusiveSchemeRanges.push({ start, end });
+        }
         // Track the domain part to avoid duplicates
-        if (match.includes('://')) {
+        if (hasExplicitAuthorityScheme(match)) {
           const domainPart = match.split('://', 2)[1].split('/')[0].split('?')[0].split('#')[0];
           schemeUrls.add(domainPart.toLowerCase());
         }
       }
     }
+    if (ownsNestedCandidates) {
+      exclusiveSchemeRanges.sort((left, right) => left.start - right.start);
+    }
   }
+
+  const schemelessScanText = exclusiveSchemeRanges.some(
+    ({ start, end }) => start === 0 && end >= text.length
+  )
+    ? ''
+    : text;
+  const extendedSchemelessCandidates: UrlCandidate[] = [];
+  for (const {
+    pattern,
+    shouldScan,
+    shouldInclude,
+    shouldIncludeAt,
+    allowNumericLeadingFinalLabel,
+    ownsToken,
+  } of NORMAL_SCHEMELESS_EXTENDED_HOST_PATTERNS) {
+    if (!shouldScan(schemelessScanText)) {
+      continue;
+    }
+    pattern.lastIndex = 0;
+    for (const result of schemelessScanText.matchAll(pattern)) {
+      const rawMatchedValue = result[0];
+      const unwrapped = unwrapPairedUrlWrapper(rawMatchedValue, text, result.index);
+      const matchedValue = cleanTrailingSchemelessUnicodeDots(unwrapped.value);
+      if (startsInsideOrdinaryEmailLocalPart(unwrapped.start)) {
+        continue;
+      }
+      if (shouldInclude && !shouldInclude(matchedValue)) {
+        continue;
+      }
+      if (shouldIncludeAt && !shouldIncludeAt(text, unwrapped.start)) {
+        continue;
+      }
+      if (!isSupportedSchemelessUrlCandidate(matchedValue, allowNumericLeadingFinalLabel)) {
+        continue;
+      }
+      let { start } = unwrapped;
+      let end = unwrapped.start + matchedValue.length;
+      if (ownsToken && matchedValue === rawMatchedValue) {
+        while (start > 0 && !URL_WHITESPACE_RE.test(text[start - 1])) {
+          start -= 1;
+        }
+        while (end < text.length && !URL_WHITESPACE_RE.test(text[end])) {
+          end += 1;
+        }
+      }
+      if (overlapsOrdinaryEmailLocalPart(start, end)) {
+        continue;
+      }
+      extendedSchemelessCandidates.push({
+        value: text.slice(start, end),
+        start,
+        end,
+      });
+    }
+  }
+  extendedSchemelessCandidates.sort(
+    (left, right) => left.start - right.start || right.end - left.end
+  );
+  const selectedExtendedSchemelessCandidates: UrlCandidate[] = [];
+  for (const candidate of extendedSchemelessCandidates) {
+    if (isInsideAmbiguousUrl(candidate.start, candidate.end)) {
+      continue;
+    }
+    if (overlapsExclusiveUrl(candidate.start, candidate.end)) {
+      continue;
+    }
+    const previous = selectedExtendedSchemelessCandidates.at(-1);
+    if (previous && candidate.start < previous.end) {
+      continue;
+    }
+    if (startsInsideOrdinaryEmailLocalPart(candidate.start)) {
+      continue;
+    }
+    detectedUrls.push(candidate.value);
+    selectedExtendedSchemelessCandidates.push(candidate);
+  }
+  exclusiveSchemeRanges.push(
+    ...selectedExtendedSchemelessCandidates.map(({ start, end }) => ({ start, end }))
+  );
+  exclusiveSchemeRanges.sort((left, right) => left.start - right.start);
 
   // Pattern 2: Domain-like patterns without schemes (exclude already found)
   const domainPattern = /\b(?:www\.)?[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}(?:\/[^\s]*)?/gi;
-  const domainMatches = text.match(domainPattern) || [];
-
-  for (let match of domainMatches) {
-    // Clean trailing punctuation
-    match = match.replace(PUNCTUATION_CLEANUP, '');
-    if (match) {
-      // Extract just the domain part for comparison
-      const domainPart = match.split('/')[0].split('?')[0].split('#')[0].toLowerCase();
-      // Only add if we haven't already found this domain with a scheme
-      if (!schemeUrls.has(domainPart)) {
-        detectedUrls.push(match);
+  if (hasPotentialAsciiDomainFinalLabel(schemelessScanText)) {
+    for (const result of schemelessScanText.matchAll(domainPattern)) {
+      const rawMatch = result[0];
+      const match = cleanPairedUrlWrapper(rawMatch, text, result.index);
+      if (match) {
+        const start = result.index;
+        const rawEnd = start + rawMatch.length;
+        if (isInsideAmbiguousUrl(start, rawEnd)) {
+          continue;
+        }
+        if (overlapsExclusiveUrl(start, rawEnd)) {
+          continue;
+        }
+        if (startsInsideOrdinaryEmailLocalPart(start)) {
+          continue;
+        }
+        // Extract just the domain part for comparison
+        const domainPart = match.split('/')[0].split('?')[0].split('#')[0].toLowerCase();
+        // Only add if we haven't already found this domain with a scheme
+        if (!schemeUrls.has(domainPart)) {
+          detectedUrls.push(match);
+        }
       }
     }
   }
 
   // Pattern 3: IP addresses (exclude already found)
   const ipPattern = /\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?::[0-9]+)?(?:\/[^\s]*)?/g;
-  const ipMatches = text.match(ipPattern) || [];
-
-  for (let match of ipMatches) {
-    // Clean trailing punctuation
-    match = match.replace(PUNCTUATION_CLEANUP, '');
+  for (const result of schemelessScanText.matchAll(ipPattern)) {
+    const rawMatch = result[0];
+    const match = cleanPairedUrlWrapper(rawMatch, text, result.index);
     if (match) {
+      const start = result.index;
+      const rawEnd = start + rawMatch.length;
+      if (isInsideAmbiguousUrl(start, rawEnd)) {
+        continue;
+      }
+      if (overlapsExclusiveUrl(start, rawEnd)) {
+        continue;
+      }
+      if (startsInsideOrdinaryEmailLocalPart(start)) {
+        continue;
+      }
       // Extract IP part for comparison
       const ipPart = match.split('/')[0].split('?')[0].split('#')[0].toLowerCase();
       if (!schemeUrls.has(ipPart)) {
@@ -197,13 +2527,14 @@ function detectUrls(text: string): string[] {
 
   // First pass: collect all domains from scheme-ful URLs
   for (const url of detectedUrls) {
-    if (url.includes('://')) {
+    if (hasExplicitAuthorityScheme(url)) {
       try {
         const parsed = new URL(url);
         if (parsed.hostname) {
-          schemeUrlDomains.add(parsed.hostname.toLowerCase());
+          const normalizedHostname = normalizeHostnameForComparison(parsed.hostname);
+          schemeUrlDomains.add(normalizedHostname);
           // Also add www-stripped version
-          const bareDomain = parsed.hostname.toLowerCase().replace(/^www\./, '');
+          const bareDomain = normalizedHostname.replace(/^www\./, '');
           schemeUrlDomains.add(bareDomain);
         }
       } catch {
@@ -220,7 +2551,7 @@ function detectUrls(text: string): string[] {
 
   // Second pass: only add scheme-less URLs if their domain isn't already covered
   for (const url of detectedUrls) {
-    if (!url.includes('://')) {
+    if (!hasExplicitAuthorityScheme(url)) {
       // Check if this domain is already covered by a full URL
       const urlLower = url.toLowerCase().replace(/^www\./, '');
       if (!schemeUrlDomains.has(urlLower)) {
@@ -244,22 +2575,35 @@ function validateUrlSecurity(
   urlString: string,
   config: UrlsConfig
 ): { parsedUrl: URL | null; reason: string; hadScheme: boolean } {
+  if (ASCII_URL_CONTROL_RE.test(urlString)) {
+    return {
+      parsedUrl: null,
+      reason: AMBIGUOUS_URL_REASON,
+      hadScheme: false,
+    };
+  }
+
   try {
     let parsedUrl: URL;
     let originalScheme: string;
     let hadScheme: boolean;
 
     // Parse URL - preserve original scheme for validation
-    if (urlString.includes('://')) {
-      // Standard URL with double-slash scheme (http://, https://, ftp://, etc.)
+    if (hasExplicitAuthorityScheme(urlString)) {
+      // Standard URL with a double-slash scheme
       parsedUrl = new URL(urlString);
       originalScheme = parsedUrl.protocol.replace(/:$/, '');
       hadScheme = true;
+    } else if (/^[\\/]{2}/.test(urlString)) {
+      // Resolve network-path references exactly as a WHATWG consumer would.
+      parsedUrl = new URL(urlString, SCHEME_RELATIVE_BASE_URL);
+      originalScheme = parsedUrl.protocol.replace(/:$/, '');
+      hadScheme = false;
     } else if (
       urlString.includes(':') &&
-      urlString.split(':', 1)[0].match(/^(data|javascript|vbscript|mailto)$/)
+      DETECTED_SCHEMES.has(urlString.split(':', 1)[0].toLowerCase())
     ) {
-      // Special single-colon schemes
+      // Recognized schemes that can omit the double slash
       parsedUrl = new URL(urlString);
       originalScheme = parsedUrl.protocol.replace(/:$/, '');
       hadScheme = true;
@@ -290,7 +2634,11 @@ function validateUrlSecurity(
     }
 
     if (config.block_userinfo && (parsedUrl.username || parsedUrl.password)) {
-      return { parsedUrl: null, reason: 'Contains userinfo (potential credential injection)', hadScheme };
+      return {
+        parsedUrl: null,
+        reason: 'Contains userinfo (potential credential injection)',
+        hadScheme,
+      };
     }
 
     // Everything else (IPs, localhost, private IPs) goes through allow list logic
@@ -299,7 +2647,11 @@ function validateUrlSecurity(
     // Provide specific error information for debugging
     const errorName = error instanceof Error ? error.name : 'Error';
     const errorMessage = error instanceof Error ? error.message : String(error);
-    return { parsedUrl: null, reason: `URL parsing error: ${errorName}: ${errorMessage}`, hadScheme: false };
+    return {
+      parsedUrl: null,
+      reason: `URL parsing error: ${errorName}: ${errorMessage}`,
+      hadScheme: false,
+    };
   }
 }
 
@@ -355,17 +2707,18 @@ function shouldBlockDueToPortMismatch(
   allowedScheme: string
 ): boolean {
   // Only enforce port matching when allow list entry explicitly specifies a non-default port
-  const allowedHasNonDefaultPort = allowedParsed.port && 
-    (allowedPort !== DEFAULT_PORTS[allowedScheme as keyof typeof DEFAULT_PORTS]);
-  
+  const allowedHasNonDefaultPort =
+    allowedParsed.port &&
+    allowedPort !== DEFAULT_PORTS[allowedScheme as keyof typeof DEFAULT_PORTS];
+
   if (!allowedHasNonDefaultPort) {
     return false; // No port restriction when allow list has no non-default port
   }
-  
+
   // Allow list has explicit non-default port, so URL must match exactly
-  const urlHasNonDefaultPort = urlParsed.port && 
-    (urlPort !== DEFAULT_PORTS[urlScheme as keyof typeof DEFAULT_PORTS]);
-  
+  const urlHasNonDefaultPort =
+    urlParsed.port && urlPort !== DEFAULT_PORTS[urlScheme as keyof typeof DEFAULT_PORTS];
+
   return !urlHasNonDefaultPort || allowedPort !== urlPort;
 }
 
@@ -377,12 +2730,17 @@ function shouldBlockDueToPortMismatch(
  * @param allowSubdomains - Whether to allow subdomains
  * @param hadScheme - Whether the original URL had an explicit scheme
  */
-function isUrlAllowed(parsedUrl: URL, allowList: string[], allowSubdomains: boolean, hadScheme: boolean): boolean {
+function isUrlAllowed(
+  parsedUrl: URL,
+  allowList: string[],
+  allowSubdomains: boolean,
+  hadScheme: boolean
+): boolean {
   if (allowList.length === 0) {
     return false;
   }
 
-  const urlHost = parsedUrl.hostname?.toLowerCase();
+  const urlHost = normalizeHostnameForComparison(parsedUrl.hostname || '');
   if (!urlHost) {
     return false;
   }
@@ -390,7 +2748,8 @@ function isUrlAllowed(parsedUrl: URL, allowList: string[], allowSubdomains: bool
   const urlDomain = urlHost.replace(/^www\./, '');
   const schemeLower = parsedUrl.protocol ? parsedUrl.protocol.replace(/:$/, '').toLowerCase() : '';
   const urlPort = safeGetPort(parsedUrl, schemeLower);
-  const hostIndicatesPort = Boolean(parsedUrl.host) && parsedUrl.host.includes(':') && !parsedUrl.host.startsWith('[');
+  const hostIndicatesPort =
+    Boolean(parsedUrl.host) && parsedUrl.host.includes(':') && !parsedUrl.host.startsWith('[');
   if (urlPort === null && hostIndicatesPort) {
     return false;
   }
@@ -462,14 +2821,19 @@ function isUrlAllowed(parsedUrl: URL, allowList: string[], allowSubdomains: bool
       continue;
     }
 
-    const allowedHost = (parsedAllowed.hostname || '').toLowerCase();
+    const allowedHost = normalizeHostnameForComparison(parsedAllowed.hostname || '');
     if (!allowedHost) {
       continue;
     }
 
-    const allowedScheme = hasExplicitScheme ? parsedAllowed.protocol.replace(/:$/, '').toLowerCase() : '';
+    const allowedScheme = hasExplicitScheme
+      ? parsedAllowed.protocol.replace(/:$/, '').toLowerCase()
+      : '';
     const allowedPort = safeGetPort(parsedAllowed, allowedScheme);
-    const allowIndicatesPort = Boolean(parsedAllowed.host) && parsedAllowed.host.includes(':') && !parsedAllowed.host.startsWith('[');
+    const allowIndicatesPort =
+      Boolean(parsedAllowed.host) &&
+      parsedAllowed.host.includes(':') &&
+      !parsedAllowed.host.startsWith('[');
     if (allowedPort === null && allowIndicatesPort) {
       continue;
     }
@@ -490,7 +2854,16 @@ function isUrlAllowed(parsedUrl: URL, allowList: string[], allowSubdomains: bool
       }
 
       // Port matching: only enforce when allow list entry explicitly specifies a non-default port
-      if (shouldBlockDueToPortMismatch(urlPort, parsedUrl, allowedPort, parsedAllowed, schemeLower, allowedScheme)) {
+      if (
+        shouldBlockDueToPortMismatch(
+          urlPort,
+          parsedUrl,
+          allowedPort,
+          parsedAllowed,
+          schemeLower,
+          allowedScheme
+        )
+      ) {
         continue;
       }
 
@@ -505,7 +2878,16 @@ function isUrlAllowed(parsedUrl: URL, allowList: string[], allowSubdomains: bool
     const allowedDomain = allowedHost.replace(/^www\./, '');
 
     // Port matching: only enforce when allow list entry explicitly specifies a non-default port
-    if (shouldBlockDueToPortMismatch(urlPort, parsedUrl, allowedPort, parsedAllowed, schemeLower, allowedScheme)) {
+    if (
+      shouldBlockDueToPortMismatch(
+        urlPort,
+        parsedUrl,
+        allowedPort,
+        parsedAllowed,
+        schemeLower,
+        allowedScheme
+      )
+    ) {
       continue;
     }
 
@@ -528,8 +2910,11 @@ function isUrlAllowed(parsedUrl: URL, allowList: string[], allowSubdomains: bool
       // so we check "/api/" not "/api//" when matching "/api/users"
       const normalizedAllowedPath = allowedPath.replace(/\/+$/, '');
       const normalizedUrlPath = urlPath.replace(/\/+$/, '');
-      
-      if (normalizedUrlPath !== normalizedAllowedPath && !normalizedUrlPath.startsWith(`${normalizedAllowedPath}/`)) {
+
+      if (
+        normalizedUrlPath !== normalizedAllowedPath &&
+        !normalizedUrlPath.startsWith(`${normalizedAllowedPath}/`)
+      ) {
         continue;
       }
     }


### PR DESCRIPTION
## Summary

Fix a URL Filter parser differential involving ASCII TAB, LF, and CR characters.

The existing detector could miss URL-like values containing these control characters, while Node's WHATWG URL parser removes them and interprets the unchanged original value as a valid URL. For example:

```text
htt<TAB>p://2130706433/internal/credentials
```

The URL Filter previously returned `tripwireTriggered: false`, but Node normalized the value to:

```text
http://127.0.0.1/internal/credentials
```

An integration that fetches the approved original string could therefore turn the detection mismatch into conditional downstream SSRF.

## Changes

- Add control-tolerant candidate detection for the URL schemes already recognized by the filter:
  - `http`
  - `https`
  - `ftp`
  - `data`
  - `javascript`
  - `vbscript`
- Fail closed with `Ambiguous URL containing ASCII control characters` when TAB, LF, or CR can affect URL interpretation.
- Detect control characters:
  - Inside schemes
  - Around authority separators
  - Inside hostnames and alternative IPv4 forms
  - Across userinfo and `@` boundaries
  - Inside paths, queries, and fragments
  - Across regex boundary characters and whitespace
- Preserve candidate source ranges so normal domain and IP detection does not emit overlapping partial URLs.
- Bridge whitespace-separated spans when WHATWG parsing can interpret later content as userinfo.
- Handle slash-less scheme-like userinfo such as:

  ```text
  https://allowed.example<LF> https:foo@2130706433
  ```

- Preserve explicit `scheme://` tokens as independent URL boundaries.
- Continue allowing ordinary multiline prose when whitespace clearly terminates the preceding URL.

The filter rejects ambiguous original values rather than approving a normalized replacement because downstream integrations may still dereference the unchanged original string.

## Security impact

This restores the expected invariant that a string approved by the URL Filter cannot become a blocked scheme, unauthorized host, or userinfo-bearing URL solely because a downstream WHATWG-compatible parser removes TAB, LF, or CR characters.

Guardrails does not make the downstream request itself, so the demonstrated impact remains conditional on an integration dereferencing the approved original value.

## Tests

Added regression coverage for:

- TAB, LF, and CR inside every position of recognized schemes
- Hierarchical URLs with zero, one, or two slash/backslash authority separators
- Decimal loopback IPv4 normalization
- Hostname continuation and authority changes
- Userinfo parser differentials
- Allowlisted host and path bypass attempts
- Candidate boundary punctuation
- Space, vertical-tab, and form-feed boundaries
- Scheme-like tokens before `@`
- Explicit `scheme://` boundaries
- Independent normal and ambiguous URLs
- Benign multiline prose
