### PR TITLE
docs: add security reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report potential security vulnerabilities through OpenAI's
+[coordinated vulnerability disclosure process](https://openai.com/policies/coordinated-vulnerability-disclosure-policy).
+For questions about that process, contact disclosure@openai.com.
+
+Do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.
+
+## What to include
+
+When reporting a potential vulnerability, please include:
+
+- The affected package or product and version, release artifact, or source
+  commit.
+- A clear description of the potential impact.
+- Sanitized reproduction steps or a minimal proof of concept.
+- Relevant runtime, environment, and known mitigations, when applicable.
+
+Do not include live credentials, API keys, customer data, or unredacted sensitive logs.
+
+This policy covers this repository and the official
+[`@openai/guardrails` npm package](https://www.npmjs.com/package/@openai/guardrails),
+including its published release artifacts. Identify the affected package version
+or release in your report.
+
+## Coordinated disclosure
+
+Please give the maintainers a reasonable opportunity to investigate and address the issue before public disclosure.
+
+Thank you for helping us keep this framework and the systems it interacts with secure.


### PR DESCRIPTION
Adds a root `SECURITY.md` so users can find the private vulnerability reporting process. Follows [openai-node’s policy](https://github.com/openai/openai-node/blob/master/.github/SECURITY.md), adapted to `@openai/guardrails`, with reporting requirements and coordinated disclosure guidance.

Validation: Prettier, ESLint, TypeScript build, and all 348 tests passed. Two consecutive adversarial review rounds (two independent reviewers each) found no blocking issues.
