### PR TITLE
ci: add SDK code ownership and merge group checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @openai/sdks-team

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+    types: [ checks_requested ]
 
 jobs:
   build-test-lint:


### PR DESCRIPTION
## Summary

Assign all files to `@openai/sdks-team` so the default-branch ruleset can enforce code-owner review, and run the existing `Build, Test, and Lint` job for `merge_group` checks. Existing push and pull-request triggers remain unchanged.

The SDK team’s explicit repository admin grant was applied and verified separately. Merge-queue enforcement should be enabled after this workflow reaches `main`.

## Validation

- `npm ci`, `npm run build`, `npm run test -- --run` (348 tests), and `npm run lint` passed.
- `actionlint .github/workflows/ci.yml` and `git diff --check` passed.
- Two consecutive independent adversarial-review rounds, including security review, found no in-scope blockers.

Dependency audit warnings from the existing lockfile are outside this configuration change.
