### PR TITLE
ci: restrict GitHub Actions permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,20 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   build-test-lint:
     name: Build, Test, and Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,24 +5,22 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  deploy_docs:
+  build_docs:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:
@@ -31,12 +29,22 @@ jobs:
         run: make sync
       - name: Build docs
         run: uv run mkdocs build --site-dir site
-      - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: site
+  deploy_docs:
+    needs: build_docs
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,15 +6,18 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  id-token: write  # Required for OIDC
-  contents: read
+permissions: {}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for npm trusted publishing
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -28,4 +31,3 @@ jobs:
       - run: npm run build --if-present
       - run: npm run test -- --run
       - run: npm publish
-


### PR DESCRIPTION
## Summary
GitHub Actions inherited broad repository write permissions, and docs dependency installation shared the Pages deployment token. Deny workflow permissions by default and grant only the permissions each job needs:

- CI and docs build: `contents: read`.
- Docs deployment: `pages: write` and `id-token: write`, isolated in a job that depends on the docs artifact.
- npm publishing: `contents: read` and `id-token: write` for trusted publishing.

Disable persisted credentials on every checkout. All action references were already pinned to full commit SHAs and remain pinned.

Repository settings have also been applied and verified: default workflow permissions are read-only, Actions PR approval is disabled, and full-SHA pinning enforcement remains enabled. These live settings are outside the Git diff.

## Validation
- actionlint 1.7.12 and git diff --check
- YAML checks for SHA pins, explicit job permissions, and disabled persisted credentials
- npm ci, npm run build, npm run test -- --run (348 passed), npm run lint
- make sync and make build-docs
- Two consecutive clean adversarial-review rounds, each with two independent fresh-context reviewers, including security review

Docs deployment and npm publication require their normal post-merge/tag events; no release or deployment was triggered for validation. Existing npm audit findings and docs navigation warnings are outside this workflow-only change.
