### PR TITLE
fix: sanitize keyword punctuation in linear time

### DIFF
--- a/src/__tests__/unit/checks/keywords-urls.test.ts
+++ b/src/__tests__/unit/checks/keywords-urls.test.ts
@@ -9,6 +9,29 @@ import { competitorsCheck } from '../../../checks/competitors';
 import { GuardrailResult } from '../../../types';
 
 describe('keywords guardrail', () => {
+  it.each([
+    ['secret.,!?;:', 'secret'],
+    ['.,!?;:', ''],
+    ['', ''],
+    ['hello!world', 'hello!world'],
+    ['!secret?', '!secret'],
+    ['secret! ', 'secret! '],
+    ['secret!\n', 'secret!\n'],
+    ['secret!\r\n', 'secret!\r\n'],
+    ['你好!?', '你好'],
+    ['hello😀!?', 'hello😀'],
+    ['secret@', 'secret@'],
+  ])('sanitizes %j to %j', (keyword, sanitized) => {
+    const result = keywordsCheck(
+      {},
+      'Ordinary input',
+      KeywordsConfig.parse({ keywords: [keyword] })
+    ) as GuardrailResult;
+
+    expect(result.info?.sanitizedKeywords).toEqual([sanitized]);
+    expect(result.info?.originalKeywords).toEqual([keyword]);
+  });
+
   it('detects keywords with trailing punctuation removed', () => {
     const result = keywordsCheck(
       {},

--- a/src/checks/keywords.ts
+++ b/src/checks/keywords.ts
@@ -59,7 +59,14 @@ export const keywordsCheck: CheckFn<KeywordsContext, string, KeywordsConfig> = (
   const { keywords } = actualConfig as KeywordsConfig;
 
   // Sanitize keywords by stripping trailing punctuation
-  const sanitizedKeywords = keywords.map((k: string) => k.replace(/[.,!?;:]+$/, ''));
+  const sanitizedKeywords = keywords.map((keyword: string) => {
+    let end = keyword.length;
+    // Scan the suffix once instead of retrying a trailing-punctuation regex.
+    while (end > 0 && '.,!?;:'.includes(keyword[end - 1])) {
+      end -= 1;
+    }
+    return keyword.slice(0, end);
+  });
 
   const keywordEntries = sanitizedKeywords
     .map((sanitized) => ({


### PR DESCRIPTION
## Summary

Keyword sanitization uses a trailing-punctuation regex that CodeQL flags for polynomial runtime on library-controlled configuration. Replace it with a single backward scan, preserving the same punctuation rules, matching behavior, and result metadata for Keyword Filter and Competitors.

Addresses [code scanning alert #2](https://github.com/openai/openai-guardrails-js/security/code-scanning/2).

## Validation

- All 359 tests pass, including 11 new bounded sanitization cases.
- `npm run lint`, `npm run build`, and `git diff --check` pass.
- Defensive security review and two consecutive clean adversarial-review rounds, each with two independent fresh-context reviewers.
