### PR TITLE
fix: avoid polynomial scanning in JSON prompt detection

### DIFF
--- a/src/__tests__/unit/llm-base.test.ts
+++ b/src/__tests__/unit/llm-base.test.ts
@@ -6,6 +6,7 @@ import {
   createLLMCheckFn,
   extractConversationHistory,
   buildAnalysisPayload,
+  buildFullPrompt,
   DEFAULT_MAX_TURNS,
 } from '../../checks/llm-base';
 import { defaultSpecRegistry } from '../../registry';
@@ -21,6 +22,37 @@ vi.mock('../../registry', () => ({
 describe('LLM Base', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('buildFullPrompt', () => {
+    it.each([
+      'Respond with a JSON object',
+      'output json',
+      'return a json object',
+      'Respond\nwith a JSON object',
+      'Use FORMAT: JSON',
+      'formatjson',
+      'Use formatting appropriate for JSON',
+      'JSON examples; format the result as json',
+      'Instructions\nformat the result as JSON',
+      'format the header; format the result as JSON',
+    ])('preserves existing JSON instructions: %s', (prompt) => {
+      expect(buildFullPrompt(prompt)).toBe(prompt);
+    });
+
+    it.each([
+      '',
+      'Check the text',
+      'Discuss JSON and then format the result',
+      'format the result as plain text',
+      ...['\n', '\r', '\u2028', '\u2029'].map((separator) => `format${separator}JSON`),
+    ])('adds JSON instructions when absent: %s', (prompt) => {
+      const result = buildFullPrompt(prompt, LLMOutput);
+      expect(result).toContain(prompt);
+      expect(result).toContain('Respond with a json object containing:');
+      expect(result).toContain('- "flagged": boolean');
+      expect(result).toContain('- "confidence": float');
+    });
   });
 
   describe('LLMConfig', () => {

--- a/src/checks/llm-base.ts
+++ b/src/checks/llm-base.ts
@@ -244,8 +244,14 @@ function buildFieldInstructionBlock(outputModel?: ZodTypeAny): string | null {
 export function buildFullPrompt(systemPrompt: string, outputModel?: ZodTypeAny): string {
   // Check if the system prompt already contains JSON output format instructions
   // Look for phrases that indicate output formatting requirements, not just mentions of JSON
-  const hasJsonOutputInstructions = /(?:respond|output|return)\s+(?:with\s+)?(?:a\s+)?json|format.*json/i.test(systemPrompt);
-  
+  const hasJsonOutputInstructions =
+    /(?:respond|output|return)\s+(?:with\s+)?(?:a\s+)?json/i.test(systemPrompt) ||
+    systemPrompt.split(/[\n\r\u2028\u2029]/).some((line) => {
+      // Only the first "format" matters; avoid rescanning a suffix for each occurrence.
+      const formatIndex = line.search(/format/i);
+      return formatIndex !== -1 && /json/i.test(line.slice(formatIndex + 6));
+    });
+
   if (hasJsonOutputInstructions) {
     // If the system prompt already has detailed JSON instructions, use it as-is
     return systemPrompt;


### PR DESCRIPTION
## Summary

Fix code scanning alert [#3](https://github.com/openai/openai-guardrails-js/security/code-scanning/3): JSON-instruction detection in `buildFullPrompt` can repeatedly scan the same prompt suffix through `format.*json`.

Search for the first `format` on each line and then for `json` in its suffix. This makes that check linear while preserving case-insensitive matching, character ordering, and all four JavaScript line-terminator boundaries. Existing response instructions and generated prompt content are unchanged.

## Validation

- `npm run build`
- `npm run test:run` — 366 tests passed across 31 files
- `npm run lint`
- Ordinary regression cases cover existing instructions, case, ordering, and line boundaries.
- Two consecutive clean adversarial-review rounds, each with two independent fresh-context read-only reviewers; defensive security review found no new concerns.

Scope is limited to the affected prompt check and its tests. No public API or architecture changes.
