### PR TITLE
fix: avoid backtracking in secret-key URL exemptions

### DIFF
--- a/src/__tests__/unit/checks/moderation-secret-keys.test.ts
+++ b/src/__tests__/unit/checks/moderation-secret-keys.test.ts
@@ -166,6 +166,58 @@ describe('moderation guardrail', () => {
 });
 
 describe('secret key guardrail', () => {
+  it.each(['balanced', 'permissive'] as const)(
+    'preserves URL exemptions in %s mode',
+    async (threshold) => {
+      const urls = [
+        'http://Example123.com',
+        'HTTPS://Example123.com/',
+        'https://Example123.com/Abc_456-def/ghi.jkl',
+        'https://Example123_com',
+        'http://a',
+        'http://.',
+        'http://-',
+      ];
+
+      for (const url of urls) {
+        const result = await secretKeysCheck({}, url, SecretKeysConfig.parse({ threshold }));
+
+        expect(result.tripwireTriggered).toBe(false);
+        expect(result.info?.masked_text).toBe(url);
+      }
+    }
+  );
+
+  it.each([
+    'https://_Example123.com/Abc456',
+    'https:///Example123.com/Abc456',
+    'https://Example123.com/Abc456?query=789',
+    'https://Example123.com/Abc456!',
+    'https://Example123.com/sk-Abc456Def789',
+  ])('does not exempt secret candidates outside the allowed URL pattern: %s', async (text) => {
+    const result = await secretKeysCheck(
+      {},
+      text,
+      SecretKeysConfig.parse({ threshold: 'balanced' })
+    );
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected_secrets).toEqual([text]);
+    expect(result.info?.masked_text).toBe('<SECRET>');
+  });
+
+  it('still checks URLs in strict mode and applies custom patterns before exemptions', async () => {
+    const text = 'https://Example123.com/Abc456';
+    for (const config of [
+      SecretKeysConfig.parse({ threshold: 'strict' }),
+      SecretKeysConfig.parse({ threshold: 'balanced', custom_regex: ['Example123'] }),
+    ]) {
+      const result = await secretKeysCheck({}, text, config);
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.masked_text).toBe('<SECRET>');
+    }
+  });
+
   it('detects and masks secret candidates', async () => {
     const text = 'Here is a token sk-1234567890 and some safe text.';
 

--- a/src/checks/secret-keys.ts
+++ b/src/checks/secret-keys.ts
@@ -172,7 +172,8 @@ function charDiversity(s: string): number {
  */
 function containsAllowedPattern(text: string): boolean {
   // Check if it's a URL pattern
-  const urlPattern = /^https?:\/\/[a-zA-Z0-9.-]+\/?[a-zA-Z0-9./_-]*$/i;
+  // Require one host character, then scan the remaining allowed characters once.
+  const urlPattern = /^https?:\/\/[a-zA-Z0-9.-][a-zA-Z0-9./_-]*$/i;
   if (urlPattern.test(text)) {
     // If it's a URL, check if it contains any secret patterns
     // If it contains secrets, don't allow it


### PR DESCRIPTION
## Summary

The secret-key guardrail's URL exemption uses overlapping character repetitions that can cause polynomial backtracking on input text (code scanning alert #4). Require one host character followed by a single repetition of the remaining allowed characters, preserving the exact accepted URL language and existing secret detection behavior.

Adds focused coverage for balanced/permissive URL exemptions, invalid URL characters, embedded secret prefixes, strict mode, and custom-pattern precedence. Scope is limited to the built-in URL exemption and its existing test file.

## Validation

- Full test suite: 31 files, 356 tests passed.
- `npm run lint` and `npm run build` passed.
- Defensive security inspection confirms the overlapping repetition is removed; no attack payloads or timing reproductions used.
- Two consecutive independent adversarial-review rounds, two fresh-context read-only reviewers per round, with no unresolved in-scope blockers.

Alert: https://github.com/openai/openai-guardrails-js/security/code-scanning/4
