### PR TITLE
fix: match safety identifier provider by parsed hostname

### DIFF
--- a/src/__tests__/unit/utils/safety-identifier.test.ts
+++ b/src/__tests__/unit/utils/safety-identifier.test.ts
@@ -35,6 +35,20 @@ describe('Safety Identifier utilities', () => {
       expect(supportsSafetyIdentifier(mockClient)).toBe(true);
     });
 
+    it.each([
+      ['https://API.OPENAI.COM/v1', true],
+      ['https://api.openai.com:443/v1/', true],
+      ['https://staging.api.openai.com/v1', false],
+      ['https://openai.com/v1', false],
+      ['/v1', false],
+      ['not a URL', false],
+      ['', false],
+    ])('should classify the parsed hostname of %s as %s', (baseURL, expected) => {
+      expect(supportsSafetyIdentifier({ baseURL })).toBe(expected);
+      expect(supportsSafetyIdentifier({ _client: { baseURL } })).toBe(expected);
+      expect(supportsSafetyIdentifier({ _baseURL: baseURL })).toBe(expected);
+    });
+
     it('should return false for Azure OpenAI client', () => {
       const mockClient = {
         constructor: { name: 'AzureOpenAI' },
@@ -125,4 +139,3 @@ describe('Safety Identifier utilities', () => {
     });
   });
 });
-

--- a/src/utils/safety-identifier.ts
+++ b/src/utils/safety-identifier.ts
@@ -56,12 +56,14 @@ export function supportsSafetyIdentifier(client: OpenAI | unknown): boolean {
     (clientObj._baseURL as string);
 
   if (baseURL !== undefined && baseURL !== null) {
-    const baseURLStr = String(baseURL);
     // Only official OpenAI API endpoints support safety_identifier
-    return baseURLStr.includes('api.openai.com');
+    try {
+      return new URL(String(baseURL)).hostname === 'api.openai.com';
+    } catch {
+      return false;
+    }
   }
 
   // Default OpenAI client (no custom baseURL) supports it
   return true;
 }
-


### PR DESCRIPTION
The safety identifier capability check currently searches the entire base URL for `api.openai.com`, which can misclassify nonofficial endpoints. Parse the URL and compare its hostname exactly, returning false when parsing fails. This addresses [code scanning alert #5](https://github.com/openai/openai-guardrails-js/security/code-scanning/5).

Preserves Azure exclusions, the default for clients without a custom URL, and all three base URL property fallbacks. Regression tests cover hostname normalization, subdomains, and invalid URLs across those fallbacks.

Validation: all 355 tests passed (`npm run test:run`), `npm run lint`, and `npm run build`. Two consecutive independent adversarial review rounds (two fresh reviewers per round), including defensive security review, completed without blocking findings.
