### PR TITLE
fix: constrain Finnish PII century markers

### DIFF
--- a/src/__tests__/unit/checks/pii.test.ts
+++ b/src/__tests__/unit/checks/pii.test.ts
@@ -43,6 +43,39 @@ describe('pii guardrail', () => {
     await expect(pii({}, '', config)).rejects.toThrow('Text cannot be empty or null');
   });
 
+  describe.each([false, true])('Finnish identity codes with block=%s', (block) => {
+    it.each(['+', '-', 'A'])('detects the supported century marker %s', async (marker) => {
+      const config = PIIConfig.parse({
+        entities: [PIIEntity.FI_PERSONAL_IDENTITY_CODE],
+        block,
+      });
+      const identityCode = `010101${marker}0101`;
+      const result = await pii({}, `ID: ${identityCode}`, config);
+
+      expect(result.tripwireTriggered).toBe(block);
+      expect(result.info?.detected_entities).toEqual({
+        FI_PERSONAL_IDENTITY_CODE: [identityCode],
+      });
+      expect(result.info?.checked_text).toBe('ID: <FI_PERSONAL_IDENTITY_CODE>');
+    });
+
+    it.each([',', '.', '/', '0', '9', ':', ';', '<', '=', '>', '?', '@'])(
+      'does not treat %s as a century marker',
+      async (marker) => {
+        const config = PIIConfig.parse({
+          entities: [PIIEntity.FI_PERSONAL_IDENTITY_CODE],
+          block,
+        });
+        const text = `ID: 010101${marker}0101`;
+        const result = await pii({}, text, config);
+
+        expect(result.tripwireTriggered).toBe(false);
+        expect(result.info?.detected_entities).toEqual({});
+        expect(result.info?.checked_text).toBe(text);
+      }
+    );
+  });
+
   it('detects valid Korean Resident Registration Number (KR_RRN)', async () => {
     const config = PIIConfig.parse({
       entities: [PIIEntity.KR_RRN],

--- a/src/checks/pii.ts
+++ b/src/checks/pii.ts
@@ -391,7 +391,7 @@ const DEFAULT_PII_PATTERNS: Record<PIIEntity, PatternDefinition[]> = {
   [PIIEntity.IN_PASSPORT]: [{ regex: /\b[A-Z]\d{7}\b/g }],
 
   // Finland
-  [PIIEntity.FI_PERSONAL_IDENTITY_CODE]: [{ regex: /\b\d{6}[+-A]\d{3}[A-Z0-9]\b/g }],
+  [PIIEntity.FI_PERSONAL_IDENTITY_CODE]: [{ regex: /\b\d{6}[+A-]\d{3}[A-Z0-9]\b/g }],
 
   // Korea
   // Format: YYMMDD-GNNNNNN where YY=year, MM=month(01-12), DD=day(01-31), G=gender/century(1-4)


### PR DESCRIPTION
## Summary
The Finnish identity-code PII pattern interpreted `[+-A]` as a character range, producing unintended detections and masking or blocking non-PII text. Move the hyphen to the end of the class so it accepts only the existing intended markers: `+`, `-`, and `A`.

Addresses [code scanning alert #6](https://github.com/openai/openai-guardrails-js/security/code-scanning/6). No other entity patterns or public APIs change.

## Validation
- Added 30 parameterized cases covering supported and unsupported century markers in masking and blocking modes.
- Full suite: 378 tests passed across 31 files.
- `npm run build`, `npm run lint`, and `git diff --check` passed.
- Defensive security review completed; two consecutive clean adversarial-review rounds, each with two independent fresh-context reviewers.
