### PR TITLE
ci: add CodeQL analysis for merge groups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  merge_group:
+    types: [ checks_requested ]
+  schedule:
+    - cron: '23 6 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ actions, javascript-typescript ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Analyze code
+        uses: github/codeql-action/analyze@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

Required CodeQL checks currently use GitHub default setup, which does not expose a `merge_group` trigger. Add a repository-owned CodeQL workflow so merge-queue commits can receive the same required analysis checks as pull requests.

The workflow scans Actions and JavaScript/TypeScript using the default queries on PRs to `main`, pushes to `main`, merge groups, weekly runs, and manual dispatch. It preserves the required `Analyze (actions)` and `Analyze (javascript-typescript)` names and existing analysis categories, pins actions, and limits permissions to reading contents and writing security results.

## Validation

- `actionlint .github/workflows/codeql.yml .github/workflows/ci.yml`
- `npm run build`
- `npm run lint`
- `npm run test -- --run`: 348 tests passed
- Two consecutive clean adversarial-review rounds with two independent reviewers each, including security review

## Rollout

Switch CodeQL from default to advanced setup to permit this workflow's uploads, then verify both analysis jobs and the CodeQL result check on this PR. All existing required checks and review requirements remain enforced. After the reviewed workflow lands and passes on `main`, enable a squash merge queue in the existing main ruleset. Queue activation is deferred until the workflow is available on the default branch.
