### PR TITLE
ci: test Node 22, 24, and 26 and require Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@ permissions: {}
 
 jobs:
   build-test-lint:
-    name: Build, Test, and Lint
+    name: Build, Test, and Lint (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24, 26]
     permissions:
       contents: read
 
@@ -26,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
@@ -40,3 +44,14 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+  ci-status:
+    name: Build, Test, and Lint
+    if: always()
+    needs: build-test-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix results
+        env:
+          MATRIX_RESULT: ${{ needs.build-test-lint.result }}
+        run: test "$MATRIX_RESULT" = success

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "vitest": "^3.2.7"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vitest": "^3.2.7"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
Raise the minimum supported Node.js version from 18 to 22 and keep the lockfile's root engine metadata aligned. Run CI installation, build, tests, and lint on Node 22, 24, and 26, with fail-fast disabled so each version reports its result. Preserve the required `Build, Test, and Lint` check with an aggregate job that succeeds only when every matrix job passes.

## Validation
- Build, all 378 tests, and lint pass locally on Node 22 and 24.
- Actionlint and git diff --check pass.
- Two consecutive independent adversarial review rounds, with two fresh reviewers per round.
- Node 26 validation runs in the CI matrix.
