### PR TITLE
Enable additional strict TypeScript compiler checks

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -590,7 +590,7 @@ export class GuardrailAgent {
 
       return new Agent({
         name,
-        instructions,
+        ...(instructions !== undefined ? { instructions } : {}),
         inputGuardrails,
         outputGuardrails,
         ...filteredAgentKwargs,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -299,10 +299,10 @@ async function handleEvalCommand(args: CliArgs): Promise<void> {
       azureApiVersion: args.azureApiVersion || '2025-01-01-preview',
       mode: args.mode || 'evaluate',
       models: args.models || null,
-      latencyIterations: args.latencyIterations,
-      multiTurn: args.multiTurn,
-      maxParallelModels: args.maxParallelModels,
-      benchmarkChunkSize: args.benchmarkChunkSize,
+      ...(args.latencyIterations !== undefined ? { latencyIterations: args.latencyIterations } : {}),
+      ...(args.multiTurn !== undefined ? { multiTurn: args.multiTurn } : {}),
+      ...(args.maxParallelModels !== undefined ? { maxParallelModels: args.maxParallelModels } : {}),
+      ...(args.benchmarkChunkSize !== undefined ? { benchmarkChunkSize: args.benchmarkChunkSize } : {}),
     });
 
     console.log('Evaluation completed successfully!');

--- a/src/evals/core/latency-tester.ts
+++ b/src/evals/core/latency-tester.ts
@@ -12,16 +12,12 @@ import { instantiateGuardrails, GuardrailBundle } from '../../runtime';
  * Tests end-to-end guardrail latency for different models.
  */
 export class LatencyTester {
-  private readonly iterations: number;
-
   /**
    * Initialize the latency tester.
    *
-   * @param iterations - Number of samples to time per model
+   * @param _iterations - Retained for compatibility; each timing call specifies its iterations.
    */
-  constructor(iterations: number = 20) {
-    this.iterations = iterations;
-  }
+  constructor(_iterations: number = 20) {}
 
   /**
    * Calculate latency statistics from a list of times.

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -62,6 +62,8 @@ export class GuardrailExecutionError extends GuardrailError {
   constructor(message: string, cause?: Error) {
     super(message);
     this.name = 'GuardrailExecutionError';
-    this.cause = cause;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
   }
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -172,7 +172,7 @@ export class GuardrailRegistry {
       mediaType: spec.mediaType,
       hasConfig: spec.configSchema !== NO_CONFIG,
       hasContext: spec.ctxRequirements !== NO_CONTEXT_REQUIREMENTS,
-      metadata: spec.metadata,
+      ...(spec.metadata !== undefined ? { metadata: spec.metadata } : {}),
     }));
   }
 }

--- a/src/utils/conversation.ts
+++ b/src/utils/conversation.ts
@@ -198,7 +198,7 @@ function normalizeMapping(item: Record<string, unknown>): NormalizedConversation
   const textContent = extractText('content' in item ? item.content : item.text);
 
   const entry = createConversationEntry({
-    role,
+    ...(role !== undefined ? { role } : {}),
     content: textContent,
     type: itemType,
   });

--- a/src/utils/vector-store.ts
+++ b/src/utils/vector-store.ts
@@ -83,7 +83,7 @@ class MemoryVectorStore implements VectorStore {
   private documents: Map<string, Document> = new Map();
   private embeddings: Map<string, number[]> = new Map();
 
-  constructor(private config: Record<string, unknown>) {}
+  constructor(_config: Record<string, unknown>) {}
 
   async addDocuments(documents: Document[]): Promise<void> {
     for (const doc of documents) {
@@ -144,7 +144,7 @@ class MemoryVectorStore implements VectorStore {
  * Placeholder implementations for other vector store types.
  */
 class PineconeVectorStore implements VectorStore {
-  constructor(private config: Record<string, unknown>) {}
+  constructor(_config: Record<string, unknown>) {}
 
   async addDocuments(_documents: Document[]): Promise<void> {
     throw new Error('Pinecone vector store not implemented');
@@ -164,7 +164,7 @@ class PineconeVectorStore implements VectorStore {
 }
 
 class WeaviateVectorStore implements VectorStore {
-  constructor(private config: Record<string, unknown>) {}
+  constructor(_config: Record<string, unknown>) {}
 
   async addDocuments(_documents: Document[]): Promise<void> {
     throw new Error('Weaviate vector store not implemented');
@@ -184,7 +184,7 @@ class WeaviateVectorStore implements VectorStore {
 }
 
 class ChromaVectorStore implements VectorStore {
-  constructor(private config: Record<string, unknown>) {}
+  constructor(_config: Record<string, unknown>) {}
 
   async addDocuments(_documents: Document[]): Promise<void> {
     throw new Error('Chroma vector store not implemented');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,12 +21,17 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noUnusedParameters": false,
-    "exactOptionalPropertyTypes": false,
+    "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": false,
-    "noUncheckedIndexedAccess": false
+    "noUncheckedIndexedAccess": false,
+    "noFallthroughCasesInSwitch": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "noUncheckedSideEffectImports": true,
+    "noEmitOnError": true
   },
   "include": ["src/**/*"],
   "exclude": [


### PR DESCRIPTION
## Summary

The TypeScript build already enables `strict`, but leaves additional compiler checks disabled. Enable `noUnusedLocals` and `exactOptionalPropertyTypes`, plus five checks that already pass: `noFallthroughCasesInSwitch`, `allowUnreachableCode: false`, `allowUnusedLabels: false`, `noUncheckedSideEffectImports`, and `noEmitOnError`.

Fix the resulting errors by omitting undefined optional properties at construction/call boundaries and removing unused private storage while retaining constructor arguments. Optional values remain accessible as `undefined` when absent; omitted `cause` and `metadata` properties are no longer emitted as own properties containing `undefined`.

## Validation

- `npm run build`
- `npm run test:run` — 422 tests passed across 31 files
- `npm run lint`
- `git diff --check`
