### PR TITLE
Enable TypeScript unused parameter checks

### DIFF
--- a/src/__tests__/integration/integration.test.ts
+++ b/src/__tests__/integration/integration.test.ts
@@ -14,7 +14,7 @@ import { CheckFn } from '../../types';
 import { loadConfigBundle } from '../../runtime';
 
 // Mock check function for testing
-const mockCheck: CheckFn<object, string, object> = (ctx, data) => ({
+const mockCheck: CheckFn<object, string, object> = (_ctx, data) => ({
   tripwireTriggered: data === 'trigger',
   info: {
     sampled_text: data,

--- a/src/__tests__/unit/agents.test.ts
+++ b/src/__tests__/unit/agents.test.ts
@@ -259,7 +259,7 @@ describe('GuardrailAgent', () => {
     it('should accept callable instructions', async () => {
       const config = { version: 1 };
 
-      const dynamicInstructions = (ctx: unknown, agent: unknown) => {
+      const dynamicInstructions = (_ctx: unknown, agent: unknown) => {
         return `You are ${(agent as { name: string }).name}`;
       };
 

--- a/src/__tests__/unit/spec.test.ts
+++ b/src/__tests__/unit/spec.test.ts
@@ -14,7 +14,7 @@ import { CheckFn, TextInput } from '../../types';
 import { z } from 'zod';
 
 // Mock check function for testing
-const mockCheck: CheckFn<object, TextInput, object> = (ctx, data) => ({
+const mockCheck: CheckFn<object, TextInput, object> = (_ctx, data) => ({
   tripwireTriggered: false,
   info: {
     sample_text: data,

--- a/src/__tests__/unit/types.test.ts
+++ b/src/__tests__/unit/types.test.ts
@@ -61,7 +61,7 @@ describe('Types Module', () => {
 
   describe('CheckFn', () => {
     it('should work with sync function', () => {
-      const syncCheck = (ctx: Record<string, unknown>, data: string): GuardrailResult => ({
+      const syncCheck = (_ctx: Record<string, unknown>, data: string): GuardrailResult => ({
         tripwireTriggered: data === 'trigger',
         info: {
           guardrail_name: 'Sync',
@@ -73,7 +73,7 @@ describe('Types Module', () => {
     });
 
     it('should work with async function', async () => {
-      const asyncCheck = async (ctx: Record<string, unknown>, data: string): Promise<GuardrailResult> => ({
+      const asyncCheck = async (_ctx: Record<string, unknown>, data: string): Promise<GuardrailResult> => ({
         tripwireTriggered: data === 'trigger',
         info: {
           guardrail_name: 'Async',
@@ -110,7 +110,7 @@ describe('Types Module', () => {
   describe('Type compatibility', () => {
     it('should allow flexible context types', () => {
       const check = (
-        ctx: { user: string },
+        _ctx: { user: string },
         data: string,
         config: { threshold: number }
       ): GuardrailResult => ({
@@ -125,7 +125,7 @@ describe('Types Module', () => {
     });
 
     it('should allow flexible input types', () => {
-      const check = (ctx: unknown, data: unknown, _config: unknown): GuardrailResult => ({
+      const check = (_ctx: unknown, data: unknown, _config: unknown): GuardrailResult => ({
         tripwireTriggered: false,
         info: {
           guardrail_name: 'FlexibleInput',
@@ -138,7 +138,7 @@ describe('Types Module', () => {
     });
 
     it('should allow flexible config types', () => {
-      const check = (ctx: unknown, data: unknown, _config: unknown): GuardrailResult => ({
+      const check = (_ctx: unknown, data: unknown, _config: unknown): GuardrailResult => ({
         tripwireTriggered: false,
         info: {
           guardrail_name: 'FlexibleConfig',

--- a/src/checks/keywords.ts
+++ b/src/checks/keywords.ts
@@ -35,7 +35,7 @@ export type KeywordsContext = z.infer<typeof KeywordsContext>;
  * Checks if any of the configured keywords appear in the input text.
  * Can be configured to trigger tripwires on matches or just report them.
  *
- * @param ctx Runtime context (unused for this guardrail)
+ * @param _ctx Runtime context (unused for this guardrail)
  * @param text Input text to check
  * @param config Configuration specifying keywords and behavior
  * @returns GuardrailResult indicating if tripwire was triggered
@@ -50,7 +50,7 @@ const isWordChar = (() => {
 })();
 
 export const keywordsCheck: CheckFn<KeywordsContext, string, KeywordsConfig> = (
-  ctx,
+  _ctx,
   text,
   config
 ): GuardrailResult => {

--- a/src/checks/secret-keys.ts
+++ b/src/checks/secret-keys.ts
@@ -270,13 +270,13 @@ function detectSecretKeys(
  * Scans the input for likely secrets or credentials (e.g., API keys, tokens)
  * using entropy, diversity, and pattern rules.
  *
- * @param ctx Guardrail context (unused).
+ * @param _ctx Guardrail context (unused).
  * @param data Input text to scan.
  * @param config Configuration for secret detection.
  * @returns GuardrailResult indicating if secrets were detected, with findings in info.
  */
 export const secretKeysCheck: CheckFn<SecretKeysContext, string, SecretKeysConfig> = async (
-  ctx,
+  _ctx,
   data,
   config
 ): Promise<GuardrailResult> => {

--- a/src/checks/urls.ts
+++ b/src/checks/urls.ts
@@ -551,7 +551,7 @@ function isUrlAllowed(parsedUrl: URL, allowList: string[], allowSubdomains: bool
 /**
  * Main URL filtering function.
  */
-export const urls: CheckFn<UrlsContext, string, UrlsConfig> = async (ctx, data, config) => {
+export const urls: CheckFn<UrlsContext, string, UrlsConfig> = async (_ctx, data, config) => {
   const actualConfig = UrlsConfig.parse(config || {});
 
   // Detect URLs in the text

--- a/src/evals/core/visualizer.ts
+++ b/src/evals/core/visualizer.ts
@@ -28,16 +28,16 @@ export class BenchmarkVisualizer {
    * Create all visualizations for a benchmark run.
    *
    * @param resultsByModel - Dictionary mapping model names to their results
-   * @param metricsByModel - Dictionary mapping model names to their metrics
-   * @param latencyResults - Dictionary mapping model names to their latency data
+   * @param _metricsByModel - Dictionary mapping model names to their metrics
+   * @param _latencyResults - Dictionary mapping model names to their latency data
    * @param guardrailName - Name of the guardrail being evaluated
    * @param _expectedTriggers - Expected trigger values for each sample (reserved for future use)
    * @returns List of paths to saved visualization files
    */
   async createAllVisualizations(
     resultsByModel: Record<string, unknown[]>,
-    metricsByModel: Record<string, Record<string, number>>,
-    latencyResults: Record<string, Record<string, unknown>>,
+    _metricsByModel: Record<string, Record<string, number>>,
+    _latencyResults: Record<string, Record<string, unknown>>,
     guardrailName: string,
     _expectedTriggers: Record<string, boolean>
   ): Promise<string[]> {

--- a/src/utils/vector-store.ts
+++ b/src/utils/vector-store.ts
@@ -94,7 +94,7 @@ class MemoryVectorStore implements VectorStore {
     }
   }
 
-  async search(query: string, limit: number = 10): Promise<SearchResult[]> {
+  async search(_query: string, limit: number = 10): Promise<SearchResult[]> {
     // Simple implementation - in a real scenario, you'd use proper similarity search
     const results: SearchResult[] = [];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
     "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": false,


### PR DESCRIPTION
## Summary

Enable TypeScript's `noUnusedParameters` check so the build rejects unintentionally unused arguments. Fix the 14 resulting errors by prefixing intentionally unused parameters with `_` and updating matching parameter documentation. Parameter positions, types, arity, and runtime behavior are unchanged.

## Validation

- `npm run build`
- `npm run test:run` — 422 tests passed across 31 files
- `npm run lint`
- `git diff --check`
