### PR TITLE
fix: preserve original message index for PII masking

### DIFF
--- a/src/__tests__/unit/base-client.test.ts
+++ b/src/__tests__/unit/base-client.test.ts
@@ -108,6 +108,26 @@ describe('GuardrailsBaseClient helpers', () => {
       expect(index).toBe(1);
     });
 
+    it.each(['text', 'input_text', 'output_text', 'summary_text'])(
+      'preserves original indices and extraction for %s in mixed histories',
+      (type) => {
+        const messages: Message[] = [
+          { role: 'user', content: 'earlier' },
+          { role: 'assistant', content: [] },
+          { role: 'user', content: [{ type: 'input_image', image_url: 'fixture' }] },
+          { role: 'user', content: [
+            { type, text: ' latest ' },
+            { type: 'input_image', image_url: 'fixture' },
+            { type, text: 'message ' },
+          ] },
+          { role: 'user', content: '   ' },
+          { role: 'user', content: [{ type: 'input_image', image_url: 'fixture' }] },
+        ];
+
+        expect(client.extractLatestUserTextMessage(messages)).toEqual(['latest  message', 3]);
+      }
+    );
+
     it('returns empty string when no user messages exist', () => {
       const messages: Message[] = [
         { role: 'assistant', content: 'hi' },

--- a/src/__tests__/unit/chat-resources.test.ts
+++ b/src/__tests__/unit/chat-resources.test.ts
@@ -6,6 +6,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GuardrailsBaseClient } from '../../base-client';
+import { Message } from '../../types';
 
 const streamSyncMock = vi.fn();
 
@@ -168,4 +170,59 @@ describe('Responses resource', () => {
     expect(payload).toEqual({ result: 'handled' });
   });
 
+});
+
+// Keep selection and masking real; only guardrail results and transport are mocked.
+describe.each(['chat', 'responses'] as const)('%s preflight masking', (api) => {
+  it.each(['string', 'text', 'input_text', 'output_text', 'summary_text'])(
+    'masks the selected original message with %s content after non-text history',
+    async (type) => {
+      const client = baseClientMock();
+      client.extractLatestUserTextMessage.mockImplementation(
+        GuardrailsBaseClient.prototype.extractLatestUserTextMessage
+      );
+      client.applyPreflightModifications.mockImplementation(
+        GuardrailsBaseClient.prototype.applyPreflightModifications
+      );
+      client.runStageGuardrails.mockResolvedValueOnce([{
+        tripwireTriggered: false,
+        info: { detected_entities: { EMAIL: ['alice@example.com'] } },
+      }]).mockResolvedValueOnce([]);
+      const image = { type: 'input_image', image_url: 'fixture' };
+      const content = type === 'string'
+        ? 'Contact alice@example.com'
+        : [{ type, text: 'Contact alice@example.com' }, image];
+      const messages: Message[] = [
+        { role: 'user', content: 'Earlier alice@example.com' },
+        { role: 'assistant', content: [] },
+        { role: 'user', content: [image] },
+        { role: 'user', content },
+        { role: 'user', content: [image] },
+      ];
+      const original = structuredClone(messages);
+      const expected = [...messages];
+      expected[3] = { role: 'user', content: type === 'string'
+        ? 'Contact <EMAIL>' : [{ type, text: 'Contact <EMAIL>' }, image] };
+
+      if (api === 'chat') {
+        const { Chat } = await import('../../resources/chat/chat');
+        const chat = new Chat(client as unknown as ConstructorParameters<typeof Chat>[0]);
+        await chat.completions.create({ messages, model: 'gpt-4o' });
+        expect(client._resourceClient.chat.completions.create).toHaveBeenCalledWith(
+          expect.objectContaining({ messages: expected }), undefined
+        );
+      } else {
+        const { Responses } = await import('../../resources/responses/responses');
+        const responses = new Responses(client as unknown as ConstructorParameters<typeof Responses>[0]);
+        await responses.create({ input: messages, model: 'gpt-4o' });
+        expect(client._resourceClient.responses.create).toHaveBeenCalledWith(
+          expect.objectContaining({ input: expected }), undefined
+        );
+      }
+      expect(client.runStageGuardrails).toHaveBeenNthCalledWith(
+        1, 'pre_flight', 'Contact alice@example.com', expect.any(Array), false, false
+      );
+      expect(messages).toEqual(original);
+    }
+  );
 });

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -150,16 +150,14 @@ export abstract class GuardrailsBaseClient {
   public raiseGuardrailErrors = false;
 
   /**
-   * Extract the latest user text message from a conversation for text guardrails.
+   * Extract the latest user text message and its original conversation index for text guardrails.
    *
    * This method specifically extracts text content from messages. For other content types,
    * create parallel methods like extractLatestUserImage() or extractLatestUserVideo().
    */
   public extractLatestUserTextMessage(messages: Message[]): [string, number] {
-    const textOnlyMessages = ContentUtils.filterToTextOnly(messages);
-
-    for (let i = textOnlyMessages.length - 1; i >= 0; i -= 1) {
-      const message = textOnlyMessages[i];
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      const message = messages[i];
       if (message.role === 'user') {
         const text = ContentUtils.extractTextFromMessage(message);
         if (text) {


### PR DESCRIPTION
## Summary

Preflight PII masking could select a different message when conversation history included messages without text. Preserve the original conversation index when selecting the latest user text so Chat Completions and Responses mask the intended message.

Public signatures, text extraction rules, supported content types, defaults, and string input behavior are preserved. Regression tests cover both adapters, mixed histories, all supported text-part types, and caller-data preservation.

## Validation

- Build/type check and lint passed.
- Full suite: 436 tests passed, including 14 new regressions.
- Documentation build/check and package dry run passed.
- Security and compatibility review completed; two independent reviewer pairs across two consecutive clean rounds.
