### PR TITLE
fix: preserve URL allowlist resource case

### DIFF
--- a/src/__tests__/unit/checks/keywords-urls.test.ts
+++ b/src/__tests__/unit/checks/keywords-urls.test.ts
@@ -294,6 +294,37 @@ describe('UrlsConfig', () => {
 });
 
 describe('urls guardrail', () => {
+  describe.each([
+    ['https://EXAMPLE.com', 'https://example.com', false],
+    ['  HtTpS://EXAMPLE.com', 'https://example.com', false],
+    ['EXAMPLE.com', 'example.com', false],
+    ['HTTPS://EXAMPLE.com', 'https://sub.example.com', true],
+  ])('resource case with allowlist prefix %s', (entryPrefix, urlPrefix, allowSubdomains) => {
+    it.each([
+      ['/Docs', '/Docs/Guide', '/docs'],
+      ['/search?Key=Value', '/search?Key=Value', '/search?key=Value'],
+      ['/search?key=Value', '/search?key=Value', '/search?key=value'],
+      ['/docs#Intro', '/docs#Intro', '/docs#intro'],
+      ['/Docs?Key=Value#Intro', '/Docs?Key=Value#Intro', '/docs?key=value#intro'],
+    ])('preserves configured resource %s', async (resource, allowedResource, blockedResource) => {
+      const allowedUrl = `${urlPrefix}${allowedResource}`;
+      const blockedUrl = `${urlPrefix}${blockedResource}`;
+      const config = UrlsConfig.parse({
+        url_allow_list: [`${entryPrefix}${resource}  `],
+        allow_subdomains: allowSubdomains,
+      });
+      const result = await urls({}, `${allowedUrl} ${blockedUrl}`, config);
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.allowed).toEqual([allowedUrl]);
+      expect(result.info?.blocked).toEqual([blockedUrl]);
+      expect(result.info?.config).toEqual({
+        ...config,
+        allowed_schemes: ['https'],
+      });
+    });
+  });
+
   it('allows https URLs listed in the allow list', async () => {
     const result = await urls(
       {},

--- a/src/checks/urls.ts
+++ b/src/checks/urls.ts
@@ -14,7 +14,7 @@ const DEFAULT_PORTS: Record<string, number> = {
   https: 443,
 };
 
-const SCHEME_PREFIX_RE = /^[a-z][a-z0-9+.-]*:\/\//;
+const SCHEME_PREFIX_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 const HOSTLESS_SCHEMES = new Set(['data', 'javascript', 'vbscript', 'mailto']);
 
 function normalizeAllowedSchemes(value: unknown): Set<string> {
@@ -402,7 +402,8 @@ function isUrlAllowed(parsedUrl: URL, allowList: string[], allowSubdomains: bool
   const urlIpInt = urlIsIp ? ipToInt(urlHost) : null;
 
   for (const allowedEntry of allowList) {
-    const normalizedEntry = allowedEntry.toLowerCase().trim();
+    // Preserve case-sensitive resource components; normalize host and scheme after parsing.
+    const normalizedEntry = allowedEntry.trim();
     if (!normalizedEntry) {
       continue;
     }


### PR DESCRIPTION
## Summary

Preserve case in URL allowlist paths, queries, and fragments so matching respects the configured resource. Scheme and hostname matching remain case-insensitive, including mixed-case explicit schemes. Public APIs, defaults, scheme-less entries, and existing matching modes remain unchanged.

## Validation

- Added 20 regression/compatibility cases covering path and subpath case, query keys and values, fragments, mixed-case scheme/host, whitespace, scheme-less entries, and optional subdomains.
- All 442 tests pass; TypeScript build, ESLint, documentation build/checks, and package dry-run pass.
- Completed static security and compatibility review of the shared check used by the client and Agents integrations, plus two consecutive clean adversarial-review rounds with two independent reviewers each.
