### PR TITLE
fix: run output checks on Responses streaming text

### DIFF
--- a/src/__tests__/unit/streaming.test.ts
+++ b/src/__tests__/unit/streaming.test.ts
@@ -158,3 +158,164 @@ describe('StreamingMixin', () => {
     expect(client.runStageGuardrails).toHaveBeenCalled();
   });
 });
+
+// Keep extraction and response wrapping real; only guardrail execution is spied on.
+class StreamingTestClient extends GuardrailsBaseClient {
+  protected createDefaultContext(): never {
+    throw new Error('No network context is needed for these fixtures');
+  }
+
+  protected overrideResources(): void {}
+}
+
+const makeResponseDelta = (
+  delta: string
+): import('openai').OpenAI.Responses.ResponseTextDeltaEvent => ({
+  type: 'response.output_text.delta',
+  delta,
+  item_id: 'message_1',
+  output_index: 0,
+  content_index: 0,
+  sequence_number: 1,
+});
+
+async function* streamEvents(events: unknown[]) {
+  yield* events;
+}
+
+describe('Responses streaming with the real text extractor', () => {
+  it.each(['async', 'sync'] as const)(
+    'checks final text once through the %s helper',
+    async (helper) => {
+      const client = new StreamingTestClient();
+      const result: GuardrailResult = { tripwireTriggered: false, info: {} };
+      const stage = vi.spyOn(client, 'runStageGuardrails').mockResolvedValue([result]);
+      const history = [{ role: 'user', content: 'Say hello' }];
+      const events = [
+        { type: 'response.created', response: { output: [] } },
+        makeResponseDelta('Hello'),
+        { type: 'response.function_call_arguments.delta', delta: 'tool arguments' },
+        { type: 'response.reasoning_summary_text.delta', delta: 'reasoning' },
+        makeResponseDelta(' world'),
+        { type: 'response.output_text.done', text: 'Hello world' },
+        { type: 'response.completed', response: { output: [], output_text: 'Hello world' } },
+      ];
+      const iterator =
+        helper === 'sync'
+          ? StreamingMixin.streamWithGuardrailsSync(client, streamEvents(events), [], [], history)
+          : new StreamingMixin().streamWithGuardrails.call(
+              client,
+              streamEvents(events),
+              [],
+              [],
+              history
+            );
+      const responses = await collectAsyncIterator(iterator);
+
+      expect(stage).toHaveBeenCalledExactlyOnceWith(
+        'output',
+        'Hello world',
+        [...history, { role: 'assistant', content: 'Hello world' }],
+        false
+      );
+      expect(responses).toHaveLength(events.length + 1);
+      for (const [index, event] of events.entries()) {
+        expect(responses[index]).toMatchObject(event);
+      }
+      expect(responses.at(-1)).toMatchObject({ type: 'final', accumulated_text: 'Hello world' });
+      expect(responses.at(-1)?.guardrail_results.output).toEqual([result]);
+      expect(history).toEqual([{ role: 'user', content: 'Say hello' }]);
+    }
+  );
+
+  it.each([false, true])(
+    'runs periodic checks with suppressTripwire=%s',
+    async (suppressTripwire) => {
+      const client = new StreamingTestClient();
+      const stage = vi.spyOn(client, 'runStageGuardrails').mockResolvedValue([]);
+      const events = [
+        makeResponseDelta('Hello'),
+        makeResponseDelta(''),
+        makeResponseDelta(' world'),
+      ];
+      await collectAsyncIterator(
+        new StreamingMixin().streamWithGuardrails.call(
+          client,
+          streamEvents(events),
+          [],
+          [],
+          [],
+          2,
+          suppressTripwire
+        )
+      );
+      expect(stage).toHaveBeenNthCalledWith(
+        1,
+        'output',
+        'Hello world',
+        [{ role: 'assistant', content: 'Hello world' }],
+        suppressTripwire
+      );
+    }
+  );
+
+  it.each([1, 100])('reports and throws an output tripwire at interval %s', async (interval) => {
+    const client = new StreamingTestClient();
+    const tripwire = new GuardrailTripwireTriggered({ tripwireTriggered: true, info: {} });
+    const stage = vi.spyOn(client, 'runStageGuardrails').mockRejectedValue(tripwire);
+    const received: GuardrailsResponse[] = [];
+    const iterator = new StreamingMixin().streamWithGuardrails.call(
+      client,
+      streamEvents([makeResponseDelta('ordinary fixture')]),
+      [],
+      [],
+      [],
+      interval
+    );
+    await expect(async () => {
+      for await (const response of iterator) received.push(response);
+    }).rejects.toBe(tripwire);
+    expect(stage).toHaveBeenCalledWith(
+      'output',
+      'ordinary fixture',
+      [{ role: 'assistant', content: 'ordinary fixture' }],
+      false
+    );
+    expect(received.at(-1)?.guardrail_results.output).toEqual([tripwire.guardrailResult]);
+  });
+
+  it('preserves Chat delta extraction', async () => {
+    const client = new StreamingTestClient();
+    const stage = vi.spyOn(client, 'runStageGuardrails').mockResolvedValue([]);
+    await collectAsyncIterator(
+      StreamingMixin.streamWithGuardrailsSync(
+        client,
+        streamEvents([makeChunk('Hello'), makeChunk(' world')]),
+        [],
+        []
+      )
+    );
+    expect(stage).toHaveBeenCalledExactlyOnceWith(
+      'output',
+      'Hello world',
+      [{ role: 'assistant', content: 'Hello world' }],
+      false
+    );
+  });
+
+  it('does not treat non-text events or empty deltas as output text', async () => {
+    const client = new StreamingTestClient();
+    const stage = vi.spyOn(client, 'runStageGuardrails').mockResolvedValue([]);
+    const events = [
+      makeResponseDelta(''),
+      { type: 'response.function_call_arguments.delta', delta: 'arguments' },
+      { type: 'response.output_text.delta', delta: null },
+      { type: 'response.output_text.delta' },
+    ];
+    const responses = await collectAsyncIterator(
+      StreamingMixin.streamWithGuardrailsSync(client, streamEvents(events), [], [])
+    );
+    expect(stage).not.toHaveBeenCalled();
+    expect(responses).toHaveLength(events.length);
+  });
+});

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -322,6 +322,12 @@ export abstract class GuardrailsBaseClient {
   }
 
   protected extractResponseText(response: OpenAIResponseType): string {
+    // Responses streams emit text deltas rather than completion objects. Only
+    // collect deltas: done/completed events repeat the text already collected.
+    if ('type' in response && response.type === 'response.output_text.delta') {
+      return 'delta' in response && typeof response.delta === 'string' ? response.delta : '';
+    }
+
     if ('output' in response) {
       return response.output_text || '';
     }


### PR DESCRIPTION
## Summary

Responses streaming text events were not recognized by the shared extractor, so configured output checks did not receive their text. Recognize `response.output_text.delta` and feed it into the existing periodic and final checks, without appending repeated done/completed snapshots.

Public signatures, raw event delivery, Chat/non-streaming extraction, and existing tripwire settings are unchanged. The shared fix covers OpenAI and Azure wrappers.

## Validation

- 430 tests pass, including real-extractor regressions for both streaming helpers, periodic/final tripwires, event preservation, and Chat compatibility.
- TypeScript build, ESLint, docs build/checks, and package dry run pass.
- Inert SSE fixtures pass through both real SDK wrappers with a mocked fetch; each performs the final output check on the complete text once.
- Two independent reviewers per round; two consecutive clean adversarial-review rounds, including security review.
