### PR TITLE
fix: preserve PII findings on encoded size rejection

### DIFF
--- a/src/__tests__/unit/checks/pii-size.test.ts
+++ b/src/__tests__/unit/checks/pii-size.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { pii, PIIConfig, PIIEntity } from '../../../checks/pii';
+
+const fixtures = [
+  { encoding: 'base64', text: 'aGVsbG8gd29ybGQh' },
+  { encoding: 'hex', text: '68656c6c6f20776f726c642121' },
+  { encoding: 'url', text: '%68%65%6c%6c%6f' },
+];
+
+// Exercise size handling with small inert candidates, without oversized inputs.
+function mockDecodedSize(encoding: string, size: number): void {
+  if (encoding === 'url') {
+    vi.spyOn(TextEncoder.prototype, 'encode').mockReturnValueOnce(new Uint8Array(size));
+  } else {
+    vi.spyOn(Buffer, 'from').mockReturnValueOnce(Buffer.alloc(size, 'x'));
+  }
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe.each(fixtures)('$encoding analysis size limit', ({ encoding, text }) => {
+  it.each([false, true])('retains plaintext findings and blocks with block=%s', async (block) => {
+    mockDecodedSize(encoding, 10_001);
+    const result = await pii({}, `john@example.com ${text}`, PIIConfig.parse({
+      entities: [PIIEntity.EMAIL_ADDRESS], block, detect_encoded_pii: true,
+    }));
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.executionFailed).not.toBe(true);
+    expect(result.info).toMatchObject({
+      detected_entities: { EMAIL_ADDRESS: ['john@example.com'] },
+      checked_text: `<EMAIL_ADDRESS> ${text}`,
+      pii_detected: true,
+      block_mode: block,
+      encoded_analysis_incomplete: true,
+      error: expect.stringContaining('Maximum allowed'),
+    });
+  });
+
+  it('blocks incomplete analysis even without plaintext PII', async () => {
+    mockDecodedSize(encoding, 10_001);
+    const result = await pii({}, text, PIIConfig.parse({
+      entities: [PIIEntity.EMAIL_ADDRESS], detect_encoded_pii: true,
+    }));
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info).toMatchObject({ detected_entities: {}, pii_detected: false, encoded_analysis_incomplete: true });
+  });
+
+  it('accepts analysis at the size limit', async () => {
+    mockDecodedSize(encoding, 10_000);
+    const result = await pii({}, `john@example.com ${text}`, PIIConfig.parse({
+      entities: [PIIEntity.EMAIL_ADDRESS], detect_encoded_pii: true,
+    }));
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.checked_text).toBe(`<EMAIL_ADDRESS> ${text}`);
+    expect(result.info).not.toHaveProperty('encoded_analysis_incomplete');
+  });
+
+  it('preserves default disabled encoded detection and plaintext masking', async () => {
+    const result = await pii({}, `john@example.com ${text}`, PIIConfig.parse({ entities: [PIIEntity.EMAIL_ADDRESS] }));
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.checked_text).toBe(`<EMAIL_ADDRESS> ${text}`);
+    expect(result.info).not.toHaveProperty('encoded_analysis_incomplete');
+  });
+});

--- a/src/__tests__/unit/pii-size-preflight.test.ts
+++ b/src/__tests__/unit/pii-size-preflight.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OpenAI, AzureOpenAI } from 'openai';
+import { GuardrailsBaseClient } from '../../base-client';
+import { defaultSpecRegistry } from '../../registry';
+import { PIIEntity } from '../../checks/pii';
+import { GuardrailTripwireTriggered } from '../../exceptions';
+import { Chat } from '../../resources/chat/chat';
+import { Responses } from '../../resources/responses/responses';
+
+class PreflightClient extends GuardrailsBaseClient {
+  constructor(resource: OpenAI, block: boolean) {
+    super();
+    this._resourceClient = resource;
+    this.context = this.createDefaultContext();
+    this.guardrails = {
+      pre_flight: [defaultSpecRegistry.get('Contains PII')!.instantiate({
+        entities: [PIIEntity.EMAIL_ADDRESS], block, detect_encoded_pii: true,
+      })],
+      input: [],
+      output: [],
+    };
+  }
+
+  protected createDefaultContext() {
+    return { guardrailLlm: this._resourceClient };
+  }
+
+  protected overrideResources(): void {
+    // Resource adapters are constructed explicitly in these tests.
+  }
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe.each(['OpenAI', 'Azure'] as const)('%s PII size rejection in preflight', (provider) => {
+  describe.each(['chat', 'responses'] as const)('%s', (api) => {
+    it.each([false, true])('blocks before transmission with block=%s, regardless of execution-error policy', async (block) => {
+      const fetch = vi.fn();
+      const resource = provider === 'Azure'
+        ? new AzureOpenAI({ apiKey: 'test-key', endpoint: 'https://example.invalid', apiVersion: '2024-10-21', fetch })
+        : new OpenAI({ apiKey: 'test-key', fetch });
+      const client = new PreflightClient(resource, block);
+      for (const raiseGuardrailErrors of [false, true]) {
+        client.raiseGuardrailErrors = raiseGuardrailErrors;
+        // The small candidate is inert; only its measured decoded size is mocked.
+        vi.spyOn(TextEncoder.prototype, 'encode').mockReturnValueOnce(new Uint8Array(10_001));
+        const text = 'john@example.com %68%65%6c%6c%6f';
+        const pending = api === 'chat'
+          ? new Chat(client).completions.create({ model: 'test-model', messages: [{ role: 'user', content: text }] })
+          : new Responses(client).create({ model: 'test-model', input: text });
+        await expect(pending).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
+        expect(fetch).not.toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/src/checks/pii.ts
+++ b/src/checks/pii.ts
@@ -9,6 +9,8 @@
  * The guardrail supports two modes of operation:
  * - **Masking mode** (block=false, default): Automatically masks PII with placeholder tokens without blocking
  * - **Blocking mode** (block=true): Triggers tripwire when PII is detected, blocking the request
+ * - With encoded detection enabled, exceeding its decoded-size limit triggers a tripwire
+ *   in either mode because the encoded content could not be fully inspected.
  *
  * **IMPORTANT: PII masking is only supported in the pre-flight stage.**
  * - Use `block=false` (masking mode) in pre-flight to automatically mask PII from user input
@@ -214,7 +216,10 @@ interface EncodedCandidate {
   type: 'base64' | 'hex' | 'url';
 }
 
+class EncodedPiiSizeError extends Error {}
+
 interface PiiDetectionResult {
+  encodedAnalysisError: EncodedPiiSizeError | undefined;
   normalizedText: string;
   plainMapping: Record<string, Set<string>>;
   encodedMapping: Record<string, Set<string>>;
@@ -416,15 +421,25 @@ function _detectPii(text: string, config: PIIConfig): PiiDetectionResult {
 
   let encodedMapping: Record<string, Set<string>> = {};
   let encodedSpans: ReplacementSpan[] = [];
+  let encodedAnalysisError: EncodedPiiSizeError | undefined;
 
   if (config.detect_encoded_pii) {
-    const encodedDetection = _detectEncodedPii(normalizedText, config);
-    encodedMapping = encodedDetection.mapping;
-    encodedSpans = encodedDetection.spans;
+    try {
+      const encodedDetection = _detectEncodedPii(normalizedText, config);
+      encodedMapping = encodedDetection.mapping;
+      encodedSpans = encodedDetection.spans;
+    } catch (error) {
+      if (!(error instanceof EncodedPiiSizeError)) {
+        throw error;
+      }
+      // Keep plaintext findings, but do not authorize content we could not inspect.
+      encodedAnalysisError = error;
+    }
   }
 
   return {
     normalizedText,
+    encodedAnalysisError,
     plainMapping: plainDetection.mapping,
     encodedMapping,
     spans: [...plainDetection.spans, ...encodedSpans],
@@ -744,12 +759,12 @@ function _tryDecodeBase64(text: string): string | null {
   try {
     const buffer = Buffer.from(sanitized, 'base64');
     if (buffer.length > MAX_DECODED_BYTES) {
-      throw new Error(`Base64 decoded content too large (${buffer.length} bytes). Maximum allowed is 10KB.`);
+      throw new EncodedPiiSizeError(`Base64 decoded content too large (${buffer.length} bytes). Maximum allowed is 10KB.`);
     }
     const decoder = new TextDecoder('utf-8', { fatal: true });
     return decoder.decode(buffer);
   } catch (error) {
-    if (error instanceof Error && error.message.includes('Maximum allowed')) {
+    if (error instanceof EncodedPiiSizeError) {
       throw error;
     }
     return null;
@@ -763,12 +778,12 @@ function _tryDecodeHex(text: string): string | null {
   try {
     const buffer = Buffer.from(text, 'hex');
     if (buffer.length > MAX_DECODED_BYTES) {
-      throw new Error(`Hex decoded content too large (${buffer.length} bytes). Maximum allowed is 10KB.`);
+      throw new EncodedPiiSizeError(`Hex decoded content too large (${buffer.length} bytes). Maximum allowed is 10KB.`);
     }
     const decoder = new TextDecoder('utf-8', { fatal: true });
     return decoder.decode(buffer);
   } catch (error) {
-    if (error instanceof Error && error.message.includes('Maximum allowed')) {
+    if (error instanceof EncodedPiiSizeError) {
       throw error;
     }
     return null;
@@ -786,11 +801,11 @@ function _tryDecodeUrl(text: string): string | null {
     const encoder = new TextEncoder();
     const length = encoder.encode(decoded).length;
     if (length > MAX_DECODED_BYTES) {
-      throw new Error(`URL decoded content too large (${length} bytes). Maximum allowed is 10KB.`);
+      throw new EncodedPiiSizeError(`URL decoded content too large (${length} bytes). Maximum allowed is 10KB.`);
     }
     return decoded;
   } catch (error) {
-    if (error instanceof Error && error.message.includes('Maximum allowed')) {
+    if (error instanceof EncodedPiiSizeError) {
       throw error;
     }
     return null;
@@ -847,8 +862,8 @@ function _asResult(
   const checkedText = hasPii ? _scrubPii(text, detection) : text;
 
   return {
-    // Only trigger tripwire if block=true AND PII is found
-    tripwireTriggered: config.block && hasPii,
+    // Incomplete encoded analysis must block even in masking mode.
+    tripwireTriggered: Boolean(detection.encodedAnalysisError) || (config.block && hasPii),
     info: {
       guardrail_name: name,
       detected_entities: detectedEntities,
@@ -856,6 +871,9 @@ function _asResult(
       checked_text: checkedText,
       block_mode: config.block,
       pii_detected: hasPii,
+      ...(detection.encodedAnalysisError
+        ? { encoded_analysis_incomplete: true, error: detection.encodedAnalysisError.message }
+        : {}),
     },
   };
 }


### PR DESCRIPTION
## Summary

Preserve plaintext PII findings when optional encoded analysis exceeds its existing decoded-size limit. Return a blocking tripwire with incomplete-analysis metadata so preflight cannot continue under the default execution-error policy.

Normal masking and blocking, supported encodings, public signatures, defaults, and explicit tripwire suppression are preserved. The correction is limited to encoded-size rejection.

## Validation

- 445 tests pass, including inert mocked size-boundary cases for Base64, hex, and URL encoding and preflight checks for Chat/Responses with OpenAI/Azure and both execution-error settings.
- TypeScript build, ESLint, documentation checks, and package dry-run pass.
- Dedicated security review and two consecutive clean adversarial-review rounds, with two independent fresh-context reviewers per round.
