### PR TITLE
fix: honor strict guardrail errors for output checks

### DIFF
--- a/src/__tests__/unit/base-client.test.ts
+++ b/src/__tests__/unit/base-client.test.ts
@@ -381,6 +381,7 @@ describe('GuardrailsBaseClient helpers', () => {
           { role: 'user', content: 'hi' },
           { role: 'assistant', content: 'All good' },
         ]),
+        false,
         false
       );
       expect((response as unknown as ResponseWithGuardrailResults).guardrail_results).toBeInstanceOf(GuardrailResultsImpl);

--- a/src/__tests__/unit/output-error-policy.test.ts
+++ b/src/__tests__/unit/output-error-policy.test.ts
@@ -41,7 +41,7 @@ class OutputTestClient extends GuardrailsBaseClient {
 describe('output execution-error policy', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  for (const failureKind of ['throw', 'result'] as const) {
+  for (const failureKind of ['throw', 'result', 'result without exception'] as const) {
     for (const strict of [true, false, undefined]) {
       describe(`${failureKind}, strict=${strict}`, () => {
         const setup = () => {
@@ -52,7 +52,7 @@ describe('output execution-error policy', () => {
             return {
               tripwireTriggered: false,
               executionFailed: true,
-              originalException: error,
+              ...(failureKind === 'result without exception' ? {} : { originalException: error }),
               info: {},
             };
           }, strict);
@@ -76,12 +76,17 @@ describe('output execution-error policy', () => {
                       suppressTripwire,
                     });
               if (strict) {
-                await expect(response).rejects.toBe(error);
+                if (failureKind === 'result without exception') {
+                  await expect(response).rejects.toThrow('Guardrail execution failed');
+                } else {
+                  await expect(response).rejects.toBe(error);
+                }
               } else {
-                expect((await response).guardrail_results.output[0]).toMatchObject({
-                  executionFailed: true,
-                  originalException: error,
-                });
+                const result = (await response).guardrail_results.output[0];
+                expect(result.executionFailed).toBe(true);
+                expect(result.originalException).toBe(
+                  failureKind === 'result without exception' ? undefined : error
+                );
               }
             });
           }
@@ -91,6 +96,7 @@ describe('output execution-error policy', () => {
           ['periodic', 1, false],
           ['periodic suppressed', 1, true],
           ['final', 100, false],
+          ['final suppressed', 100, true],
         ] as const) {
           it(`streaming ${checkpoint}`, async () => {
             const { client, error } = setup();
@@ -111,21 +117,54 @@ describe('output execution-error policy', () => {
               for await (const response of iterator) yielded.push(response);
             };
             if (strict) {
-              await expect(consume()).rejects.toBe(error);
+              if (failureKind === 'result without exception') {
+                await expect(consume()).rejects.toThrow('Guardrail execution failed');
+              } else {
+                await expect(consume()).rejects.toBe(error);
+              }
               // A final check can fail after chunks were streamed, but emits no successful final result.
               expect(yielded).toHaveLength(interval === 1 ? 0 : 1);
             } else {
               await consume();
               expect(yielded).toHaveLength(suppressTripwire ? 1 : 2);
               if (!suppressTripwire) {
-                expect(yielded[1].guardrail_results.output[0]).toMatchObject({
-                  executionFailed: true,
-                  originalException: error,
-                });
+                const result = yielded[1].guardrail_results.output[0];
+                expect(result.executionFailed).toBe(true);
+                expect(result.originalException).toBe(
+                  failureKind === 'result without exception' ? undefined : error
+                );
               }
             }
           });
         }
+      });
+    }
+  }
+
+  for (const strict of [true, false, undefined]) {
+    for (const tripwireTriggered of [false, true]) {
+      it(`preserves suppressed short-stream output with strict=${strict}, tripwire=${tripwireTriggered}`, async () => {
+        const check = vi.fn(() => ({ tripwireTriggered, info: {} }));
+        const client = new OutputTestClient(check, strict);
+        const chunk = { choices: [{ delta: { content: 'Hello' } }] };
+        async function* chunks() {
+          yield chunk;
+        }
+        const yielded: GuardrailsResponse[] = [];
+        for await (const response of StreamingMixin.streamWithGuardrailsSync(
+          client,
+          chunks(),
+          [],
+          [],
+          [],
+          true
+        )) {
+          yielded.push(response);
+        }
+        expect(check).toHaveBeenCalledTimes(strict ? 1 : 0);
+        expect(yielded).toHaveLength(1);
+        expect(yielded[0]).toMatchObject(chunk);
+        expect(yielded[0].guardrail_results.output).toEqual([]);
       });
     }
   }

--- a/src/__tests__/unit/output-error-policy.test.ts
+++ b/src/__tests__/unit/output-error-policy.test.ts
@@ -6,6 +6,7 @@ import { GuardrailLLMContext, GuardrailResult } from '../../types';
 import { Chat } from '../../resources/chat';
 import { Responses } from '../../resources/responses';
 import { StreamingMixin } from '../../streaming';
+import { GuardrailTripwireTriggered } from '../../exceptions';
 
 class OutputTestClient extends GuardrailsBaseClient {
   constructor(check: () => GuardrailResult, strict: boolean | undefined) {
@@ -41,14 +42,22 @@ class OutputTestClient extends GuardrailsBaseClient {
 describe('output execution-error policy', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  for (const failureKind of ['throw', 'result', 'result without exception'] as const) {
+  for (const failureKind of [
+    'throw',
+    'result',
+    'result without exception',
+    'tripwire throw',
+    'tripwire result',
+  ] as const) {
     for (const strict of [true, false, undefined]) {
       describe(`${failureKind}, strict=${strict}`, () => {
         const setup = () => {
           vi.spyOn(console, 'error').mockImplementation(() => undefined);
-          const error = new Error('Inert check unavailable');
+          const error = failureKind.startsWith('tripwire')
+            ? Object.freeze(new GuardrailTripwireTriggered({ tripwireTriggered: true, info: {} }))
+            : new Error('Inert check unavailable');
           const client = new OutputTestClient(() => {
-            if (failureKind === 'throw') throw error;
+            if (failureKind === 'throw' || failureKind === 'tripwire throw') throw error;
             return {
               tripwireTriggered: false,
               executionFailed: true,
@@ -168,4 +177,120 @@ describe('output execution-error policy', () => {
       });
     }
   }
+
+  for (const api of ['chat', 'responses'] as const) {
+    for (const count of [99, 100, 101, 200]) {
+      for (const suppressTripwire of [false, true]) {
+        it(`${api}: checks only pending suppressed text after ${count} chunks, suppression=${suppressTripwire}`, async () => {
+          const check = vi.fn(() => ({ tripwireTriggered: false, info: {} }));
+          const client = new OutputTestClient(check, true);
+          async function* chunks() {
+            for (let index = 0; index < count; index++) {
+              yield api === 'chat'
+                ? { choices: [{ delta: { content: 'Hello' } }] }
+                : { type: 'response.output_text.delta', delta: 'Hello' };
+            }
+            yield { type: 'response.output_text.delta', delta: '' };
+            yield { type: 'response.output_text.done', text: 'Hello' };
+          }
+          const yielded: GuardrailsResponse[] = [];
+          for await (const response of StreamingMixin.streamWithGuardrailsSync(
+            client,
+            chunks(),
+            [],
+            [],
+            [],
+            suppressTripwire
+          )) {
+            yielded.push(response);
+          }
+          const finalChecks = !suppressTripwire || count % 100 !== 0 ? 1 : 0;
+          expect(check).toHaveBeenCalledTimes(Math.floor(count / 100) + finalChecks);
+          expect(yielded).toHaveLength(count + 2 + (suppressTripwire ? 0 : 1));
+        });
+      }
+    }
+  }
+
+  for (const interval of [1, 100]) {
+    it(`prioritizes execution failures over violations at interval ${interval}`, async () => {
+      const error = Object.freeze(
+        new GuardrailTripwireTriggered({ tripwireTriggered: false, info: {} })
+      );
+      const client = new OutputTestClient(
+        () => ({
+          tripwireTriggered: true,
+          executionFailed: true,
+          originalException: error,
+          info: {},
+        }),
+        true
+      );
+      async function* chunks() {
+        yield { type: 'response.output_text.delta', delta: 'Hello' };
+      }
+      const yielded: GuardrailsResponse[] = [];
+      await expect(async () => {
+        for await (const response of new StreamingMixin().streamWithGuardrails.call(
+          client,
+          chunks(),
+          [],
+          [],
+          [],
+          interval
+        ))
+          yielded.push(response);
+      }).rejects.toBe(error);
+      expect(yielded).toHaveLength(interval === 1 ? 0 : 1);
+    });
+
+    it(`still emits genuine violations before rejecting at interval ${interval}`, async () => {
+      const result = { tripwireTriggered: true, info: {} };
+      const client = new OutputTestClient(() => result, true);
+      async function* chunks() {
+        yield { type: 'response.output_text.delta', delta: 'Hello' };
+      }
+      const yielded: GuardrailsResponse[] = [];
+      await expect(async () => {
+        for await (const response of new StreamingMixin().streamWithGuardrails.call(
+          client,
+          chunks(),
+          [],
+          [],
+          [],
+          interval
+        ))
+          yielded.push(response);
+      }).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
+      expect(yielded).toHaveLength(interval === 1 ? 1 : 2);
+      expect(yielded.at(-1)?.guardrail_results.output).toEqual([result]);
+    });
+  }
+
+  it('applies strict policy enabled after a non-strict checkpoint', async () => {
+    const error = new Error('Inert check failure');
+    const check = vi.fn(() => ({
+      tripwireTriggered: false,
+      executionFailed: true,
+      originalException: error,
+      info: {},
+    }));
+    const client = new OutputTestClient(check, false);
+    async function* chunks() {
+      yield { type: 'response.output_text.delta', delta: 'Hello' };
+      client.raiseGuardrailErrors = true;
+    }
+    const iterator = new StreamingMixin().streamWithGuardrails.call(
+      client,
+      chunks(),
+      [],
+      [],
+      [],
+      1,
+      true
+    );
+    expect((await iterator.next()).done).toBe(false);
+    await expect(iterator.next()).rejects.toBe(error);
+    expect(check).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/__tests__/unit/output-error-policy.test.ts
+++ b/src/__tests__/unit/output-error-policy.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OpenAI } from 'openai';
+import { GuardrailsBaseClient, GuardrailsResponse } from '../../base-client';
+import { GuardrailRegistry } from '../../registry';
+import { GuardrailLLMContext, GuardrailResult } from '../../types';
+import { Chat } from '../../resources/chat';
+import { Responses } from '../../resources/responses';
+import { StreamingMixin } from '../../streaming';
+
+class OutputTestClient extends GuardrailsBaseClient {
+  constructor(check: () => GuardrailResult, strict: boolean | undefined) {
+    super();
+    const registry = new GuardrailRegistry();
+    registry.register('Output fixture', vi.fn(check), 'Inert output check');
+    this.guardrails = {
+      pre_flight: [],
+      input: [],
+      output: [registry.get('Output fixture')!.instantiate({})],
+    };
+    this._resourceClient = new OpenAI({ apiKey: 'test-key' });
+    this.context = this.createDefaultContext();
+    if (strict !== undefined) this.raiseGuardrailErrors = strict;
+    vi.spyOn(this._resourceClient.chat.completions, 'create').mockResolvedValue({
+      choices: [{ message: { role: 'assistant', content: 'Hello' } }],
+    } as OpenAI.Chat.Completions.ChatCompletion);
+    vi.spyOn(this._resourceClient.responses, 'create').mockResolvedValue({
+      output: [],
+      output_text: 'Hello',
+    } as unknown as OpenAI.Responses.Response);
+  }
+
+  protected createDefaultContext(): GuardrailLLMContext {
+    return { guardrailLlm: this._resourceClient };
+  }
+
+  protected overrideResources(): void {
+    /* Resources are constructed explicitly below. */
+  }
+}
+
+describe('output execution-error policy', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  for (const failureKind of ['throw', 'result'] as const) {
+    for (const strict of [true, false, undefined]) {
+      describe(`${failureKind}, strict=${strict}`, () => {
+        const setup = () => {
+          vi.spyOn(console, 'error').mockImplementation(() => undefined);
+          const error = new Error('Inert check unavailable');
+          const client = new OutputTestClient(() => {
+            if (failureKind === 'throw') throw error;
+            return {
+              tripwireTriggered: false,
+              executionFailed: true,
+              originalException: error,
+              info: {},
+            };
+          }, strict);
+          return { client, error };
+        };
+
+        for (const suppressTripwire of [false, true]) {
+          for (const api of ['chat', 'responses'] as const) {
+            it(`${api} non-streaming, suppressTripwire=${suppressTripwire}`, async () => {
+              const { client, error } = setup();
+              const response =
+                api === 'chat'
+                  ? new Chat(client).completions.create({
+                      model: 'test-model',
+                      messages: [{ role: 'user', content: 'Hi' }],
+                      suppressTripwire,
+                    })
+                  : new Responses(client).create({
+                      model: 'test-model',
+                      input: 'Hi',
+                      suppressTripwire,
+                    });
+              if (strict) {
+                await expect(response).rejects.toBe(error);
+              } else {
+                expect((await response).guardrail_results.output[0]).toMatchObject({
+                  executionFailed: true,
+                  originalException: error,
+                });
+              }
+            });
+          }
+        }
+
+        for (const [checkpoint, interval, suppressTripwire] of [
+          ['periodic', 1, false],
+          ['periodic suppressed', 1, true],
+          ['final', 100, false],
+        ] as const) {
+          it(`streaming ${checkpoint}`, async () => {
+            const { client, error } = setup();
+            async function* chunks() {
+              yield { choices: [{ delta: { content: 'Hello' } }] };
+            }
+            const iterator = new StreamingMixin().streamWithGuardrails.call(
+              client,
+              chunks(),
+              [],
+              [],
+              [],
+              interval,
+              suppressTripwire
+            );
+            const yielded: GuardrailsResponse[] = [];
+            const consume = async () => {
+              for await (const response of iterator) yielded.push(response);
+            };
+            if (strict) {
+              await expect(consume()).rejects.toBe(error);
+              // A final check can fail after chunks were streamed, but emits no successful final result.
+              expect(yielded).toHaveLength(interval === 1 ? 0 : 1);
+            } else {
+              await consume();
+              expect(yielded).toHaveLength(suppressTripwire ? 1 : 2);
+              if (!suppressTripwire) {
+                expect(yielded[1].guardrail_results.output[0]).toMatchObject({
+                  executionFailed: true,
+                  originalException: error,
+                });
+              }
+            }
+          });
+        }
+      });
+    }
+  }
+});

--- a/src/__tests__/unit/streaming.test.ts
+++ b/src/__tests__/unit/streaming.test.ts
@@ -216,6 +216,7 @@ describe('Responses streaming with the real text extractor', () => {
         'output',
         'Hello world',
         [...history, { role: 'assistant', content: 'Hello world' }],
+        false,
         false
       );
       expect(responses).toHaveLength(events.length + 1);
@@ -254,7 +255,8 @@ describe('Responses streaming with the real text extractor', () => {
         'output',
         'Hello world',
         [{ role: 'assistant', content: 'Hello world' }],
-        suppressTripwire
+        suppressTripwire,
+        false
       );
     }
   );
@@ -279,6 +281,7 @@ describe('Responses streaming with the real text extractor', () => {
       'output',
       'ordinary fixture',
       [{ role: 'assistant', content: 'ordinary fixture' }],
+      false,
       false
     );
     expect(received.at(-1)?.guardrail_results.output).toEqual([tripwire.guardrailResult]);
@@ -299,6 +302,7 @@ describe('Responses streaming with the real text extractor', () => {
       'output',
       'Hello world',
       [{ role: 'assistant', content: 'Hello world' }],
+      false,
       false
     );
   });

--- a/src/__tests__/unit/streaming.test.ts
+++ b/src/__tests__/unit/streaming.test.ts
@@ -7,7 +7,6 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StreamingMixin } from '../../streaming';
-import { GuardrailTripwireTriggered } from '../../exceptions';
 import { GuardrailsBaseClient, GuardrailResultsImpl, GuardrailsResponse } from '../../base-client';
 import { GuardrailResult } from '../../types';
 
@@ -104,14 +103,12 @@ describe('StreamingMixin', () => {
   });
 
   it('propagates tripwire errors during periodic checks but yields final response', async () => {
-    const tripwire = new GuardrailTripwireTriggered({
+    const result: GuardrailResult = {
       tripwireTriggered: true,
       info: { guardrail_name: 'Test' },
-    });
+    };
 
-    client.runStageGuardrails.mockImplementationOnce(async () => {
-      throw tripwire;
-    });
+    client.runStageGuardrails.mockResolvedValueOnce([result]);
 
     async function* mockStream() {
       yield makeChunk('tripwire');
@@ -132,7 +129,7 @@ describe('StreamingMixin', () => {
       for await (const value of iterator) {
         results.push(value);
       }
-    }).rejects.toBe(tripwire);
+    }).rejects.toMatchObject({ guardrailResult: result });
 
     expect(results).toHaveLength(1);
     expect(results[0].guardrail_results.output).toHaveLength(1);
@@ -216,7 +213,7 @@ describe('Responses streaming with the real text extractor', () => {
         'output',
         'Hello world',
         [...history, { role: 'assistant', content: 'Hello world' }],
-        false,
+        true,
         false
       );
       expect(responses).toHaveLength(events.length + 1);
@@ -255,7 +252,7 @@ describe('Responses streaming with the real text extractor', () => {
         'output',
         'Hello world',
         [{ role: 'assistant', content: 'Hello world' }],
-        suppressTripwire,
+        true,
         false
       );
     }
@@ -263,8 +260,8 @@ describe('Responses streaming with the real text extractor', () => {
 
   it.each([1, 100])('reports and throws an output tripwire at interval %s', async (interval) => {
     const client = new StreamingTestClient();
-    const tripwire = new GuardrailTripwireTriggered({ tripwireTriggered: true, info: {} });
-    const stage = vi.spyOn(client, 'runStageGuardrails').mockRejectedValue(tripwire);
+    const result: GuardrailResult = { tripwireTriggered: true, info: {} };
+    const stage = vi.spyOn(client, 'runStageGuardrails').mockResolvedValue([result]);
     const received: GuardrailsResponse[] = [];
     const iterator = new StreamingMixin().streamWithGuardrails.call(
       client,
@@ -276,15 +273,15 @@ describe('Responses streaming with the real text extractor', () => {
     );
     await expect(async () => {
       for await (const response of iterator) received.push(response);
-    }).rejects.toBe(tripwire);
+    }).rejects.toMatchObject({ guardrailResult: result });
     expect(stage).toHaveBeenCalledWith(
       'output',
       'ordinary fixture',
       [{ role: 'assistant', content: 'ordinary fixture' }],
-      false,
+      true,
       false
     );
-    expect(received.at(-1)?.guardrail_results.output).toEqual([tripwire.guardrailResult]);
+    expect(received.at(-1)?.guardrail_results.output).toEqual([result]);
   });
 
   it('preserves Chat delta extraction', async () => {
@@ -302,7 +299,7 @@ describe('Responses streaming with the real text extractor', () => {
       'output',
       'Hello world',
       [{ role: 'assistant', content: 'Hello world' }],
-      false,
+      true,
       false
     );
   });

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -17,6 +17,7 @@ import {
   aggregateTokenUsageFromInfos,
 } from './types';
 import { ContentUtils } from './utils/content';
+import { getGuardrailFailure } from './utils/guardrail-failure';
 import {
   GuardrailBundle,
   ConfiguredGuardrail,
@@ -462,20 +463,9 @@ export abstract class GuardrailsBaseClient {
         }
       }
 
-      if (raiseGuardrailErrors) {
-        const executionFailures = results.filter((r) => r.executionFailed);
-        if (executionFailures.length > 0) {
-          throw executionFailures[0].originalException ?? new Error('Guardrail execution failed');
-        }
-      }
-
-      if (!suppressTripwire) {
-        for (const result of results) {
-          if (result.tripwireTriggered) {
-            const { GuardrailTripwireTriggered } = await import('./exceptions');
-            throw new GuardrailTripwireTriggered(result);
-          }
-        }
+      const failure = getGuardrailFailure(results, suppressTripwire, raiseGuardrailErrors);
+      if (failure) {
+        throw failure.error;
       }
 
       return results;

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -465,7 +465,7 @@ export abstract class GuardrailsBaseClient {
       if (raiseGuardrailErrors) {
         const executionFailures = results.filter((r) => r.executionFailed);
         if (executionFailures.length > 0) {
-          throw executionFailures[0].originalException;
+          throw executionFailures[0].originalException ?? new Error('Guardrail execution failed');
         }
       }
 

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -640,7 +640,8 @@ export abstract class GuardrailsBaseClient {
       'output',
       responseText,
       completeConversation,
-      suppressTripwire
+      suppressTripwire,
+      this.raiseGuardrailErrors
     );
 
     return this.createGuardrailsResponse(llmResponse, preflightResults, inputResults, outputResults);

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -73,7 +73,7 @@ export class StreamingMixin {
       yield response;
     }
 
-    if (!suppressTripwire && accumulatedText) {
+    if ((!suppressTripwire || this.raiseGuardrailErrors) && accumulatedText) {
       try {
         const history = mergeConversationWithItems(baseHistory, [
           { role: 'assistant', content: accumulatedText },
@@ -86,13 +86,15 @@ export class StreamingMixin {
           this.raiseGuardrailErrors
         );
 
-        const finalResponse = this.createGuardrailsResponse(
-          { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
-          preflightResults,
-          inputResults,
-          finalOutputResults
-        );
-        yield finalResponse;
+        if (!suppressTripwire) {
+          const finalResponse = this.createGuardrailsResponse(
+            { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
+            preflightResults,
+            inputResults,
+            finalOutputResults
+          );
+          yield finalResponse;
+        }
       } catch (error) {
         if (error instanceof GuardrailTripwireTriggered) {
           const finalResponse = this.createGuardrailsResponse(

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -7,7 +7,7 @@
 
 import { GuardrailResult } from './types';
 import { GuardrailsResponse, GuardrailsBaseClient, OpenAIResponseType } from './base-client';
-import { GuardrailTripwireTriggered } from './exceptions';
+import { getGuardrailFailure } from './utils/guardrail-failure';
 import { mergeConversationWithItems, NormalizedConversationEntry } from './utils/conversation';
 
 /**
@@ -28,7 +28,10 @@ export class StreamingMixin {
   ): AsyncIterableIterator<GuardrailsResponse> {
     let accumulatedText = '';
     let chunkCount = 0;
-    const baseHistory = conversationHistory ? conversationHistory.map((entry) => ({ ...entry })) : [];
+    let lastStrictCheckedTextLength = 0;
+    const baseHistory = conversationHistory
+      ? conversationHistory.map((entry) => ({ ...entry }))
+      : [];
 
     for await (const chunk of llmStream) {
       const chunkText = this.extractResponseText(chunk as OpenAIResponseType);
@@ -37,30 +40,30 @@ export class StreamingMixin {
         chunkCount += 1;
 
         if (chunkCount % checkInterval === 0) {
-          try {
-            const history = mergeConversationWithItems(baseHistory, [
-              { role: 'assistant', content: accumulatedText },
-            ]);
-            await this.runStageGuardrails(
-              'output',
-              accumulatedText,
-              history,
-              suppressTripwire,
-              this.raiseGuardrailErrors
-            );
-          } catch (error) {
-            if (error instanceof GuardrailTripwireTriggered) {
-              const finalResponse = this.createGuardrailsResponse(
+          const history = mergeConversationWithItems(baseHistory, [
+            { role: 'assistant', content: accumulatedText },
+          ]);
+          // Collect results first: the original execution error may itself be a tripwire error.
+          const results = await this.runStageGuardrails(
+            'output',
+            accumulatedText,
+            history,
+            true,
+            false
+          );
+          const failure = getGuardrailFailure(results, suppressTripwire, this.raiseGuardrailErrors);
+          if (failure) {
+            if (failure.kind === 'tripwire') {
+              yield this.createGuardrailsResponse(
                 chunk as OpenAIResponseType,
                 preflightResults,
                 inputResults,
-                [error.guardrailResult]
+                [failure.error.guardrailResult]
               );
-              yield finalResponse;
-              throw error;
             }
-            throw error;
+            throw failure.error;
           }
+          if (this.raiseGuardrailErrors) lastStrictCheckedTextLength = accumulatedText.length;
         }
       }
 
@@ -73,40 +76,42 @@ export class StreamingMixin {
       yield response;
     }
 
-    if ((!suppressTripwire || this.raiseGuardrailErrors) && accumulatedText) {
-      try {
-        const history = mergeConversationWithItems(baseHistory, [
-          { role: 'assistant', content: accumulatedText },
-        ]);
-        const finalOutputResults = await this.runStageGuardrails(
-          'output',
-          accumulatedText,
-          history,
-          suppressTripwire,
-          this.raiseGuardrailErrors
+    const needsStrictFinalCheck =
+      this.raiseGuardrailErrors && accumulatedText.length > lastStrictCheckedTextLength;
+    if ((!suppressTripwire || needsStrictFinalCheck) && accumulatedText) {
+      const history = mergeConversationWithItems(baseHistory, [
+        { role: 'assistant', content: accumulatedText },
+      ]);
+      const finalOutputResults = await this.runStageGuardrails(
+        'output',
+        accumulatedText,
+        history,
+        true,
+        false
+      );
+      const failure = getGuardrailFailure(
+        finalOutputResults,
+        suppressTripwire,
+        this.raiseGuardrailErrors
+      );
+      if (failure) {
+        if (failure.kind === 'tripwire') {
+          yield this.createGuardrailsResponse(
+            { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
+            preflightResults,
+            inputResults,
+            [failure.error.guardrailResult]
+          );
+        }
+        throw failure.error;
+      }
+      if (!suppressTripwire) {
+        yield this.createGuardrailsResponse(
+          { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
+          preflightResults,
+          inputResults,
+          finalOutputResults
         );
-
-        if (!suppressTripwire) {
-          const finalResponse = this.createGuardrailsResponse(
-            { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
-            preflightResults,
-            inputResults,
-            finalOutputResults
-          );
-          yield finalResponse;
-        }
-      } catch (error) {
-        if (error instanceof GuardrailTripwireTriggered) {
-          const finalResponse = this.createGuardrailsResponse(
-            { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
-            preflightResults,
-            inputResults,
-            [error.guardrailResult]
-          );
-          yield finalResponse;
-          throw error;
-        }
-        throw error;
       }
     }
   }

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -41,7 +41,13 @@ export class StreamingMixin {
             const history = mergeConversationWithItems(baseHistory, [
               { role: 'assistant', content: accumulatedText },
             ]);
-            await this.runStageGuardrails('output', accumulatedText, history, suppressTripwire);
+            await this.runStageGuardrails(
+              'output',
+              accumulatedText,
+              history,
+              suppressTripwire,
+              this.raiseGuardrailErrors
+            );
           } catch (error) {
             if (error instanceof GuardrailTripwireTriggered) {
               const finalResponse = this.createGuardrailsResponse(
@@ -76,7 +82,8 @@ export class StreamingMixin {
           'output',
           accumulatedText,
           history,
-          suppressTripwire
+          suppressTripwire,
+          this.raiseGuardrailErrors
         );
 
         const finalResponse = this.createGuardrailsResponse(

--- a/src/utils/guardrail-failure.ts
+++ b/src/utils/guardrail-failure.ts
@@ -1,0 +1,30 @@
+import { GuardrailTripwireTriggered } from '../exceptions';
+import { GuardrailResult } from '../types';
+
+type GuardrailFailure =
+  { kind: 'execution'; error: Error } | { kind: 'tripwire'; error: GuardrailTripwireTriggered };
+
+/** Classify results before throwing so execution errors retain their provenance. */
+export function getGuardrailFailure(
+  results: GuardrailResult[],
+  suppressTripwire: boolean,
+  raiseGuardrailErrors: boolean
+): GuardrailFailure | undefined {
+  if (raiseGuardrailErrors) {
+    const failure = results.find((result) => result.executionFailed);
+    if (failure) {
+      return {
+        kind: 'execution',
+        error: failure.originalException ?? new Error('Guardrail execution failed'),
+      };
+    }
+  }
+
+  if (!suppressTripwire) {
+    const violation = results.find((result) => result.tripwireTriggered);
+    if (violation) {
+      return { kind: 'tripwire', error: new GuardrailTripwireTriggered(violation) };
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
Output checks previously ignored the client's `raiseGuardrailErrors` setting. Apply the selected execution-error policy to non-streaming and streaming output checks shared by Chat Completions, Responses, OpenAI, and Azure clients.

An internal result-classification helper keeps execution failures distinct from violations. Streaming collects results before applying the same policy as the stage runner, so even a frozen `GuardrailTripwireTriggered` supplied as an execution error is rethrown unchanged without emitting its attached result or the checked chunk. Genuine violations retain their existing notification and suppression behavior. Failed results without an original exception receive a fallback Error.

Strict suppressed streams check remaining text at EOF, including short streams, but skip the extra check when a strict checkpoint already covered the complete text. Public signatures, root exports, default fail-open behavior, and unsuppressed streaming cadence remain unchanged. Earlier chunks may still have been emitted before a later check fails.

Validation:
- 699 tests passed, including 147 output-policy cases and regressions for checkpoint boundaries, trailing events, frozen tripwire-shaped execution errors, failure precedence, missing exceptions, strict/default settings, both API shapes and genuine tripwire notifications.
- 864 additional built-package cases passed across OpenAI/Azure, both resource APIs/namespaces, streaming/non-streaming, suppression, strict/default settings and exception shapes. Model methods were mocked; no network calls occurred.
- Build, strict test-file type checking, lint, docs checks, package dry run, and root-export compatibility check passed.
- Two consecutive independent adversarial review rounds, including security and compatibility review, completed without in-scope blockers for the final patch.
