### PR TITLE
Validate all Chat completion choices independently

### DIFF
--- a/.changeset/validate-chat-choices.md
+++ b/.changeset/validate-chat-choices.md
@@ -1,0 +1,5 @@
+---
+"@openai/guardrails": patch
+---
+
+Validate every Chat completion choice independently, including streamed alternatives, with concurrent output checks. Preserve ordered final results and strict execution-error handling. Multi-choice streams now return final validation results even when tripwire exceptions are suppressed.

--- a/src/__tests__/unit/additional-choices.test.ts
+++ b/src/__tests__/unit/additional-choices.test.ts
@@ -1,0 +1,123 @@
+/** Inert, mocked-provider regressions for validation of Chat alternatives. */
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { OpenAI } from 'openai';
+import { GuardrailsBaseClient, GuardrailsResponse, OpenAIResponseType } from '../../base-client';
+import { GuardrailLLMContext, GuardrailLLMContextWithHistory, GuardrailResult } from '../../types';
+import { StreamingMixin } from '../../streaming';
+import { GuardrailTripwireTriggered } from '../../exceptions';
+import { GuardrailSpec } from '../../spec';
+
+class ChoiceClient extends GuardrailsBaseClient {
+  readonly check = vi.fn((context: GuardrailLLMContext, text: string): GuardrailResult => ({
+    tripwireTriggered: text === 'second choice',
+    info: { text, history: (context as GuardrailLLMContextWithHistory).getConversationHistory?.() },
+  }));
+
+  constructor() {
+    super();
+    this.context = this.createDefaultContext();
+    this.guardrails = {
+      pre_flight: [], input: [], output: [new GuardrailSpec(
+        'Inert check', 'Choice fixture', 'text/plain', z.object({}),
+        (context, text) => this.check(context as GuardrailLLMContext, text),
+        z.object({}), { usesConversationHistory: true }
+      ).instantiate({})],
+    };
+  }
+
+  protected createDefaultContext(): GuardrailLLMContext {
+    return { guardrailLlm: new OpenAI({ apiKey: 'test' }) };
+  }
+
+  protected overrideResources(): void { /* No transport needed for shared-handler tests. */ }
+
+  handle(response: OpenAIResponseType, suppressTripwire = false) {
+    return this.handleLlmResponse(response, [], [], [{ role: 'user', content: 'question' }], suppressTripwire);
+  }
+}
+
+const completion = (contents: Array<string | null>) => ({
+  id: 'fixture', object: 'chat.completion', created: 0, model: 'fixture',
+  choices: contents.map((content, index) => ({
+    index, message: { role: 'assistant', content, refusal: null }, finish_reason: 'stop', logprobs: null,
+  })),
+} as OpenAI.Chat.Completions.ChatCompletion);
+
+const chunk = (parts: Array<[number, string | null]>) => ({
+  id: 'fixture', object: 'chat.completion.chunk', created: 0, model: 'fixture',
+  choices: parts.map(([index, content]) => ({ index, delta: { content }, finish_reason: null, logprobs: null })),
+} as OpenAI.Chat.Completions.ChatCompletionChunk);
+
+async function* stream(chunks: OpenAI.Chat.Completions.ChatCompletionChunk[]) { yield* chunks; }
+async function collect(iterator: AsyncIterableIterator<GuardrailsResponse>) {
+  const results: GuardrailsResponse[] = [];
+  for await (const response of iterator) { results.push(response); }
+  return results;
+}
+
+describe('Chat choice validation', () => {
+  it('applies the tripwire to a later choice', async () => {
+    const client = new ChoiceClient();
+    await expect(client.handle(completion(['first choice', 'second choice']))).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'second choice']);
+  });
+
+  it('keeps alternatives and their conversation contexts separate in suppressed mode', async () => {
+    const client = new ChoiceClient();
+    const original = completion(['first choice', 'second choice', 'third choice']);
+    const response = await client.handle(original, true);
+    expect(response).toHaveProperty('choices', original.choices);
+    expect(response.guardrail_results.output.map((result) => result.tripwireTriggered)).toEqual([false, true, false]);
+    for (const [context, text] of client.check.mock.calls) {
+      expect((context as GuardrailLLMContextWithHistory).getConversationHistory?.()).toEqual([
+        { role: 'user', content: 'question' }, { role: 'assistant', content: text },
+      ]);
+    }
+  });
+
+  it('preserves single-choice and textless response handling', async () => {
+    const client = new ChoiceClient();
+    const response = await client.handle(completion(['first choice']));
+    expect(response.guardrail_results.output).toHaveLength(1);
+    await client.handle(completion([null, 'third choice']));
+    await expect(client.handle(completion([]))).resolves.toHaveProperty('choices', []);
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', '', 'third choice', '']);
+  });
+
+  it.each([false, true])('tracks reordered, interleaved streamed choices independently (suppressed=%s)', async (suppressed) => {
+    const client = new ChoiceClient();
+    client.check.mockImplementation((context, text) => ({ tripwireTriggered: false, info: { text, history: (context as GuardrailLLMContextWithHistory).getConversationHistory?.() } }));
+    const chunks = [chunk([[1, 'other'], [0, 'first']]), chunk([[0, ' choice']]), chunk([[1, ' answer']]), chunk([]), chunk([[0, null]])];
+    const responses = await collect(StreamingMixin.prototype.streamWithGuardrails.call(client, stream(chunks), [], [], [{ role: 'user', content: 'question' }], 2, suppressed));
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'other answer', 'other answer', 'first choice']);
+    for (const [context, text] of client.check.mock.calls) {
+      expect((context as GuardrailLLMContextWithHistory).getConversationHistory?.()).toEqual([{ role: 'user', content: 'question' }, { role: 'assistant', content: text }]);
+    }
+    responses.slice(0, chunks.length).forEach((response, index) => {
+      expect(response).toHaveProperty('choices', chunks[index].choices);
+    });
+    expect(responses.at(-1)).toMatchObject({ type: 'final', accumulated_text: 'first choice' });
+    expect(responses.at(-1)?.guardrail_results.output).toHaveLength(2);
+  });
+
+  it.each([1, 100])('triggers on a later streamed choice at interval %s', async (interval) => {
+    const client = new ChoiceClient();
+    const iterator = StreamingMixin.prototype.streamWithGuardrails.call(client, stream([chunk([[0, 'first choice'], [1, 'second choice']])]), [], [], [], interval, false);
+    await expect(collect(iterator)).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'second choice']);
+  });
+
+  it('returns final results for every choice in a short suppressed stream', async () => {
+    const client = new ChoiceClient();
+    const responses = await collect(StreamingMixin.streamWithGuardrailsSync(client, stream([chunk([[0, 'first choice'], [1, 'second choice']])]), [], [], [], true));
+    expect(responses.at(-1)?.guardrail_results.output.map((result) => result.tripwireTriggered)).toEqual([false, true]);
+  });
+
+  it('handles a textless first choice and usage-only chunks', async () => {
+    const client = new ChoiceClient();
+    const responses = await collect(StreamingMixin.streamWithGuardrailsSync(client, stream([chunk([[0, null], [1, 'second choice']]), chunk([])]), [], [], [], true));
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['second choice']);
+    expect(responses.at(-1)?.guardrail_results.tripwiresTriggered).toBe(true);
+  });
+});

--- a/src/__tests__/unit/additional-choices.test.ts
+++ b/src/__tests__/unit/additional-choices.test.ts
@@ -167,4 +167,43 @@ describe('Chat choice validation', () => {
     }
   });
 
+
+  it.each([false, true])('settles final checks concurrently in choice order (tripwire=%s)', async (tripwire) => {
+    const client = new ChoiceClient();
+    let finishFirst!: (results: GuardrailResult[]) => void;
+    let finishSecond!: (results: GuardrailResult[]) => void;
+    let rejectSecond!: (error: Error) => void;
+    let secondStarted!: () => void;
+    const started = new Promise<void>((resolve) => { secondStarted = resolve; });
+    const first = new Promise<GuardrailResult[]>((resolve) => { finishFirst = resolve; });
+    const second = new Promise<GuardrailResult[]>((resolve, reject) => { finishSecond = resolve; rejectSecond = reject; });
+    const check = vi.spyOn(client, 'runStageGuardrails')
+      .mockImplementationOnce(() => first)
+      .mockImplementationOnce(() => { secondStarted(); return second; });
+    const original = chunk([[1, 'second choice'], [0, 'first choice']]);
+    const iterator = StreamingMixin.streamWithGuardrailsSync(client, stream([original]), [], [], []);
+    await iterator.next();
+    const next = iterator.next();
+    const firstResult: GuardrailResult = { tripwireTriggered: false, info: { text: 'first' } };
+    const secondResult: GuardrailResult = { tripwireTriggered: tripwire, info: { text: 'second' } };
+    const error = new GuardrailTripwireTriggered(secondResult);
+    try {
+      await started;
+      expect(check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'second choice']);
+      if (tripwire) { rejectSecond(error); } else { finishSecond([secondResult]); }
+      finishFirst([firstResult]);
+      const final = (await next).value;
+      expect(final.guardrail_results.output).toEqual([firstResult, secondResult]);
+      if (tripwire) {
+        await expect(iterator.next()).rejects.toBe(error);
+      } else {
+        expect((await iterator.next()).done).toBe(true);
+      }
+    } finally {
+      finishFirst([]);
+      finishSecond([]);
+      await iterator.return(undefined);
+    }
+  });
+
 });

--- a/src/__tests__/unit/additional-choices.test.ts
+++ b/src/__tests__/unit/additional-choices.test.ts
@@ -90,7 +90,7 @@ describe('Chat choice validation', () => {
     client.check.mockImplementation((context, text) => ({ tripwireTriggered: false, info: { text, history: (context as GuardrailLLMContextWithHistory).getConversationHistory?.() } }));
     const chunks = [chunk([[1, 'other'], [0, 'first']]), chunk([[0, ' choice']]), chunk([[1, ' answer']]), chunk([]), chunk([[0, null]])];
     const responses = await collect(StreamingMixin.prototype.streamWithGuardrails.call(client, stream(chunks), [], [], [{ role: 'user', content: 'question' }], 2, suppressed));
-    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'other answer', 'other answer', 'first choice']);
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'other answer', 'first choice', 'other answer']);
     for (const [context, text] of client.check.mock.calls) {
       expect((context as GuardrailLLMContextWithHistory).getConversationHistory?.()).toEqual([{ role: 'user', content: 'question' }, { role: 'assistant', content: text }]);
     }
@@ -98,7 +98,7 @@ describe('Chat choice validation', () => {
       expect(response).toHaveProperty('choices', chunks[index].choices);
     });
     expect(responses.at(-1)).toMatchObject({ type: 'final', accumulated_text: 'first choice' });
-    expect(responses.at(-1)?.guardrail_results.output).toHaveLength(2);
+    expect(responses.at(-1)?.guardrail_results.output.map((result) => result.info.text)).toEqual(['first choice', 'other answer']);
   });
 
   it.each([1, 100])('triggers on a later streamed choice at interval %s', async (interval) => {
@@ -120,4 +120,51 @@ describe('Chat choice validation', () => {
     expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['second choice']);
     expect(responses.at(-1)?.guardrail_results.tripwiresTriggered).toBe(true);
   });
+
+  it('retains earlier final results and token usage when a later choice trips', async () => {
+    const client = new ChoiceClient();
+    client.check.mockImplementation((_context, text) => ({
+      tripwireTriggered: text === 'second choice',
+      info: { text, token_usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 } },
+    }));
+    const responses: GuardrailsResponse[] = [];
+    const iterator = StreamingMixin.streamWithGuardrailsSync(client, stream([
+      chunk([[1, 'second choice'], [0, 'first choice']]),
+    ]), [], [], []);
+    await expect(async () => {
+      for await (const response of iterator) { responses.push(response); }
+    }).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
+    const final = responses.at(-1);
+    expect(final).toMatchObject({ type: 'final', accumulated_text: 'first choice' });
+    expect(final?.guardrail_results.output.map((result) => result.info.text)).toEqual(['first choice', 'second choice']);
+    expect(final?.guardrail_results.totalTokenUsage).toMatchObject({ total_tokens: 10 });
+  });
+
+  it('starts all periodic choice checks before waiting for any to finish', async () => {
+    const client = new ChoiceClient();
+    let finishFirst!: (results: GuardrailResult[]) => void;
+    let finishSecond!: (results: GuardrailResult[]) => void;
+    let secondStarted!: () => void;
+    const started = new Promise<void>((resolve) => { secondStarted = resolve; });
+    const first = new Promise<GuardrailResult[]>((resolve) => { finishFirst = resolve; });
+    const second = new Promise<GuardrailResult[]>((resolve) => { finishSecond = resolve; });
+    const check = vi.spyOn(client, 'runStageGuardrails')
+      .mockImplementationOnce(() => first)
+      .mockImplementationOnce(() => { secondStarted(); return second; });
+    const original = chunk([[0, 'first choice'], [1, 'other choice']]);
+    const iterator = StreamingMixin.prototype.streamWithGuardrails.call(client, stream([original]), [], [], [], 1, false);
+    const next = iterator.next();
+    try {
+      await started;
+      expect(check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'other choice']);
+      finishSecond([]);
+      finishFirst([]);
+      expect((await next).value).toHaveProperty('choices', original.choices);
+    } finally {
+      finishFirst([]);
+      finishSecond([]);
+      await iterator.return(undefined);
+    }
+  });
+
 });

--- a/src/__tests__/unit/additional-choices.test.ts
+++ b/src/__tests__/unit/additional-choices.test.ts
@@ -1,28 +1,50 @@
 /** Inert, mocked-provider regressions for validation of Chat alternatives. */
+
+import { OpenAI } from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { OpenAI } from 'openai';
-import { GuardrailsBaseClient, GuardrailsResponse, OpenAIResponseType } from '../../base-client';
-import { GuardrailLLMContext, GuardrailLLMContextWithHistory, GuardrailResult } from '../../types';
-import { StreamingMixin } from '../../streaming';
+import {
+  GuardrailsBaseClient,
+  type GuardrailsResponse,
+  type OpenAIResponseType,
+} from '../../base-client';
 import { GuardrailTripwireTriggered } from '../../exceptions';
 import { GuardrailSpec } from '../../spec';
+import { StreamingMixin } from '../../streaming';
+import type {
+  GuardrailLLMContext,
+  GuardrailLLMContextWithHistory,
+  GuardrailResult,
+} from '../../types';
 
 class ChoiceClient extends GuardrailsBaseClient {
-  readonly check = vi.fn((context: GuardrailLLMContext, text: string): GuardrailResult => ({
-    tripwireTriggered: text === 'second choice',
-    info: { text, history: (context as GuardrailLLMContextWithHistory).getConversationHistory?.() },
-  }));
+  readonly check = vi.fn(
+    (context: GuardrailLLMContext, text: string): GuardrailResult => ({
+      tripwireTriggered: text === 'second choice',
+      info: {
+        text,
+        history: (context as GuardrailLLMContextWithHistory).getConversationHistory?.(),
+      },
+    })
+  );
 
   constructor() {
     super();
     this.context = this.createDefaultContext();
     this.guardrails = {
-      pre_flight: [], input: [], output: [new GuardrailSpec(
-        'Inert check', 'Choice fixture', 'text/plain', z.object({}),
-        (context, text) => this.check(context as GuardrailLLMContext, text),
-        z.object({}), { usesConversationHistory: true }
-      ).instantiate({})],
+      pre_flight: [],
+      input: [],
+      output: [
+        new GuardrailSpec(
+          'Inert check',
+          'Choice fixture',
+          'text/plain',
+          z.object({}),
+          (context, text) => this.check(context as GuardrailLLMContext, text),
+          z.object({}),
+          { usesConversationHistory: true }
+        ).instantiate({}),
+      ],
     };
   }
 
@@ -30,37 +52,70 @@ class ChoiceClient extends GuardrailsBaseClient {
     return { guardrailLlm: new OpenAI({ apiKey: 'test' }) };
   }
 
-  protected overrideResources(): void { /* No transport needed for shared-handler tests. */ }
+  protected overrideResources(): void {
+    /* No transport needed for shared-handler tests. */
+  }
 
   handle(response: OpenAIResponseType, suppressTripwire = false) {
-    return this.handleLlmResponse(response, [], [], [{ role: 'user', content: 'question' }], suppressTripwire);
+    return this.handleLlmResponse(
+      response,
+      [],
+      [],
+      [{ role: 'user', content: 'question' }],
+      suppressTripwire
+    );
   }
 }
 
-const completion = (contents: Array<string | null>) => ({
-  id: 'fixture', object: 'chat.completion', created: 0, model: 'fixture',
-  choices: contents.map((content, index) => ({
-    index, message: { role: 'assistant', content, refusal: null }, finish_reason: 'stop', logprobs: null,
-  })),
-} as OpenAI.Chat.Completions.ChatCompletion);
+const completion = (contents: Array<string | null>) =>
+  ({
+    id: 'fixture',
+    object: 'chat.completion',
+    created: 0,
+    model: 'fixture',
+    choices: contents.map((content, index) => ({
+      index,
+      message: { role: 'assistant', content, refusal: null },
+      finish_reason: 'stop',
+      logprobs: null,
+    })),
+  }) as OpenAI.Chat.Completions.ChatCompletion;
 
-const chunk = (parts: Array<[number, string | null]>) => ({
-  id: 'fixture', object: 'chat.completion.chunk', created: 0, model: 'fixture',
-  choices: parts.map(([index, content]) => ({ index, delta: { content }, finish_reason: null, logprobs: null })),
-} as OpenAI.Chat.Completions.ChatCompletionChunk);
+const chunk = (parts: Array<[number, string | null]>) =>
+  ({
+    id: 'fixture',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'fixture',
+    choices: parts.map(([index, content]) => ({
+      index,
+      delta: { content },
+      finish_reason: null,
+      logprobs: null,
+    })),
+  }) as OpenAI.Chat.Completions.ChatCompletionChunk;
 
-async function* stream(chunks: OpenAI.Chat.Completions.ChatCompletionChunk[]) { yield* chunks; }
+async function* stream(chunks: OpenAI.Chat.Completions.ChatCompletionChunk[]) {
+  yield* chunks;
+}
 async function collect(iterator: AsyncIterableIterator<GuardrailsResponse>) {
   const results: GuardrailsResponse[] = [];
-  for await (const response of iterator) { results.push(response); }
+  for await (const response of iterator) {
+    results.push(response);
+  }
   return results;
 }
 
 describe('Chat choice validation', () => {
   it('applies the tripwire to a later choice', async () => {
     const client = new ChoiceClient();
-    await expect(client.handle(completion(['first choice', 'second choice']))).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
-    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'second choice']);
+    await expect(
+      client.handle(completion(['first choice', 'second choice']))
+    ).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual([
+      'first choice',
+      'second choice',
+    ]);
   });
 
   it('keeps alternatives and their conversation contexts separate in suppressed mode', async () => {
@@ -68,10 +123,15 @@ describe('Chat choice validation', () => {
     const original = completion(['first choice', 'second choice', 'third choice']);
     const response = await client.handle(original, true);
     expect(response).toHaveProperty('choices', original.choices);
-    expect(response.guardrail_results.output.map((result) => result.tripwireTriggered)).toEqual([false, true, false]);
+    expect(response.guardrail_results.output.map((result) => result.tripwireTriggered)).toEqual([
+      false,
+      true,
+      false,
+    ]);
     for (const [context, text] of client.check.mock.calls) {
       expect((context as GuardrailLLMContextWithHistory).getConversationHistory?.()).toEqual([
-        { role: 'user', content: 'question' }, { role: 'assistant', content: text },
+        { role: 'user', content: 'question' },
+        { role: 'assistant', content: text },
       ]);
     }
   });
@@ -82,42 +142,133 @@ describe('Chat choice validation', () => {
     expect(response.guardrail_results.output).toHaveLength(1);
     await client.handle(completion([null, 'third choice']));
     await expect(client.handle(completion([]))).resolves.toHaveProperty('choices', []);
-    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', '', 'third choice', '']);
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual([
+      'first choice',
+      '',
+      'third choice',
+      '',
+    ]);
   });
 
-  it.each([false, true])('tracks reordered, interleaved streamed choices independently (suppressed=%s)', async (suppressed) => {
-    const client = new ChoiceClient();
-    client.check.mockImplementation((context, text) => ({ tripwireTriggered: false, info: { text, history: (context as GuardrailLLMContextWithHistory).getConversationHistory?.() } }));
-    const chunks = [chunk([[1, 'other'], [0, 'first']]), chunk([[0, ' choice']]), chunk([[1, ' answer']]), chunk([]), chunk([[0, null]])];
-    const responses = await collect(StreamingMixin.prototype.streamWithGuardrails.call(client, stream(chunks), [], [], [{ role: 'user', content: 'question' }], 2, suppressed));
-    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'other answer', 'first choice', 'other answer']);
-    for (const [context, text] of client.check.mock.calls) {
-      expect((context as GuardrailLLMContextWithHistory).getConversationHistory?.()).toEqual([{ role: 'user', content: 'question' }, { role: 'assistant', content: text }]);
+  it.each([false, true])(
+    'tracks reordered, interleaved streamed choices independently (suppressed=%s)',
+    async (suppressed) => {
+      const client = new ChoiceClient();
+      client.check.mockImplementation((context, text) => ({
+        tripwireTriggered: false,
+        info: {
+          text,
+          history: (context as GuardrailLLMContextWithHistory).getConversationHistory?.(),
+        },
+      }));
+      const chunks = [
+        chunk([
+          [1, 'other'],
+          [0, 'first'],
+        ]),
+        chunk([[0, ' choice']]),
+        chunk([[1, ' answer']]),
+        chunk([]),
+        chunk([[0, null]]),
+      ];
+      const responses = await collect(
+        StreamingMixin.prototype.streamWithGuardrails.call(
+          client,
+          stream(chunks),
+          [],
+          [],
+          [{ role: 'user', content: 'question' }],
+          2,
+          suppressed
+        )
+      );
+      expect(client.check.mock.calls.map(([, text]) => text)).toEqual([
+        'first choice',
+        'other answer',
+        'first choice',
+        'other answer',
+      ]);
+      for (const [context, text] of client.check.mock.calls) {
+        expect((context as GuardrailLLMContextWithHistory).getConversationHistory?.()).toEqual([
+          { role: 'user', content: 'question' },
+          { role: 'assistant', content: text },
+        ]);
+      }
+      responses.slice(0, chunks.length).forEach((response, index) => {
+        expect(response).toHaveProperty('choices', chunks[index].choices);
+      });
+      expect(responses.at(-1)).toMatchObject({ type: 'final', accumulated_text: 'first choice' });
+      expect(responses.at(-1)?.guardrail_results.output.map((result) => result.info.text)).toEqual([
+        'first choice',
+        'other answer',
+      ]);
     }
-    responses.slice(0, chunks.length).forEach((response, index) => {
-      expect(response).toHaveProperty('choices', chunks[index].choices);
-    });
-    expect(responses.at(-1)).toMatchObject({ type: 'final', accumulated_text: 'first choice' });
-    expect(responses.at(-1)?.guardrail_results.output.map((result) => result.info.text)).toEqual(['first choice', 'other answer']);
-  });
+  );
 
   it.each([1, 100])('triggers on a later streamed choice at interval %s', async (interval) => {
     const client = new ChoiceClient();
-    const iterator = StreamingMixin.prototype.streamWithGuardrails.call(client, stream([chunk([[0, 'first choice'], [1, 'second choice']])]), [], [], [], interval, false);
+    const iterator = StreamingMixin.prototype.streamWithGuardrails.call(
+      client,
+      stream([
+        chunk([
+          [0, 'first choice'],
+          [1, 'second choice'],
+        ]),
+      ]),
+      [],
+      [],
+      [],
+      interval,
+      false
+    );
     await expect(collect(iterator)).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
-    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'second choice']);
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual([
+      'first choice',
+      'second choice',
+    ]);
   });
 
   it('returns final results for every choice in a short suppressed stream', async () => {
     const client = new ChoiceClient();
-    const responses = await collect(StreamingMixin.streamWithGuardrailsSync(client, stream([chunk([[0, 'first choice'], [1, 'second choice']])]), [], [], [], true));
-    expect(responses.at(-1)?.guardrail_results.output.map((result) => result.tripwireTriggered)).toEqual([false, true]);
+    const responses = await collect(
+      StreamingMixin.streamWithGuardrailsSync(
+        client,
+        stream([
+          chunk([
+            [0, 'first choice'],
+            [1, 'second choice'],
+          ]),
+        ]),
+        [],
+        [],
+        [],
+        true
+      )
+    );
+    expect(
+      responses.at(-1)?.guardrail_results.output.map((result) => result.tripwireTriggered)
+    ).toEqual([false, true]);
   });
 
   it('handles a textless first choice and usage-only chunks', async () => {
     const client = new ChoiceClient();
-    const responses = await collect(StreamingMixin.streamWithGuardrailsSync(client, stream([chunk([[0, null], [1, 'second choice']]), chunk([])]), [], [], [], true));
-    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['second choice']);
+    const responses = await collect(
+      StreamingMixin.streamWithGuardrailsSync(
+        client,
+        stream([
+          chunk([
+            [0, null],
+            [1, 'second choice'],
+          ]),
+          chunk([]),
+        ]),
+        [],
+        [],
+        [],
+        true
+      )
+    );
+    expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['', 'second choice']);
     expect(responses.at(-1)?.guardrail_results.tripwiresTriggered).toBe(true);
   });
 
@@ -128,15 +279,29 @@ describe('Chat choice validation', () => {
       info: { text, token_usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 } },
     }));
     const responses: GuardrailsResponse[] = [];
-    const iterator = StreamingMixin.streamWithGuardrailsSync(client, stream([
-      chunk([[1, 'second choice'], [0, 'first choice']]),
-    ]), [], [], []);
+    const iterator = StreamingMixin.streamWithGuardrailsSync(
+      client,
+      stream([
+        chunk([
+          [1, 'second choice'],
+          [0, 'first choice'],
+        ]),
+      ]),
+      [],
+      [],
+      []
+    );
     await expect(async () => {
-      for await (const response of iterator) { responses.push(response); }
+      for await (const response of iterator) {
+        responses.push(response);
+      }
     }).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
     const final = responses.at(-1);
     expect(final).toMatchObject({ type: 'final', accumulated_text: 'first choice' });
-    expect(final?.guardrail_results.output.map((result) => result.info.text)).toEqual(['first choice', 'second choice']);
+    expect(final?.guardrail_results.output.map((result) => result.info.text)).toEqual([
+      'first choice',
+      'second choice',
+    ]);
     expect(final?.guardrail_results.totalTokenUsage).toMatchObject({ total_tokens: 10 });
   });
 
@@ -145,14 +310,35 @@ describe('Chat choice validation', () => {
     let finishFirst!: (results: GuardrailResult[]) => void;
     let finishSecond!: (results: GuardrailResult[]) => void;
     let secondStarted!: () => void;
-    const started = new Promise<void>((resolve) => { secondStarted = resolve; });
-    const first = new Promise<GuardrailResult[]>((resolve) => { finishFirst = resolve; });
-    const second = new Promise<GuardrailResult[]>((resolve) => { finishSecond = resolve; });
-    const check = vi.spyOn(client, 'runStageGuardrails')
+    const started = new Promise<void>((resolve) => {
+      secondStarted = resolve;
+    });
+    const first = new Promise<GuardrailResult[]>((resolve) => {
+      finishFirst = resolve;
+    });
+    const second = new Promise<GuardrailResult[]>((resolve) => {
+      finishSecond = resolve;
+    });
+    const check = vi
+      .spyOn(client, 'runStageGuardrails')
       .mockImplementationOnce(() => first)
-      .mockImplementationOnce(() => { secondStarted(); return second; });
-    const original = chunk([[0, 'first choice'], [1, 'other choice']]);
-    const iterator = StreamingMixin.prototype.streamWithGuardrails.call(client, stream([original]), [], [], [], 1, false);
+      .mockImplementationOnce(() => {
+        secondStarted();
+        return second;
+      });
+    const original = chunk([
+      [0, 'first choice'],
+      [1, 'other choice'],
+    ]);
+    const iterator = StreamingMixin.prototype.streamWithGuardrails.call(
+      client,
+      stream([original]),
+      [],
+      [],
+      [],
+      1,
+      false
+    );
     const next = iterator.next();
     try {
       await started;
@@ -167,51 +353,77 @@ describe('Chat choice validation', () => {
     }
   });
 
-
-  it.each([false, true])('settles final checks concurrently in choice order (tripwire=%s)', async (tripwire) => {
-    const client = new ChoiceClient();
-    let finishFirst!: (results: GuardrailResult[]) => void;
-    let finishSecond!: (results: GuardrailResult[]) => void;
-    let secondStarted!: () => void;
-    const started = new Promise<void>((resolve) => { secondStarted = resolve; });
-    const first = new Promise<GuardrailResult[]>((resolve) => { finishFirst = resolve; });
-    const second = new Promise<GuardrailResult[]>((resolve) => { finishSecond = resolve; });
-    const check = vi.spyOn(client, 'runStageGuardrails')
-      .mockImplementationOnce(() => first)
-      .mockImplementationOnce(() => { secondStarted(); return second; });
-    const original = chunk([[1, 'second choice'], [0, 'first choice']]);
-    const iterator = StreamingMixin.streamWithGuardrailsSync(client, stream([original]), [], [], []);
-    await iterator.next();
-    const next = iterator.next();
-    const firstResult: GuardrailResult = { tripwireTriggered: false, info: { text: 'first' } };
-    const secondResult: GuardrailResult = { tripwireTriggered: tripwire, info: { text: 'second' } };
-    try {
-      await started;
-      expect(check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'second choice']);
-      finishSecond([secondResult]);
-      finishFirst([firstResult]);
-      const final = (await next).value;
-      expect(final.guardrail_results.output).toEqual([firstResult, secondResult]);
-      if (tripwire) {
-        await expect(iterator.next()).rejects.toMatchObject({ guardrailResult: secondResult });
-      } else {
-        expect((await iterator.next()).done).toBe(true);
+  it.each([false, true])(
+    'settles final checks concurrently in choice order (tripwire=%s)',
+    async (tripwire) => {
+      const client = new ChoiceClient();
+      let finishFirst!: (results: GuardrailResult[]) => void;
+      let finishSecond!: (results: GuardrailResult[]) => void;
+      let secondStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        secondStarted = resolve;
+      });
+      const first = new Promise<GuardrailResult[]>((resolve) => {
+        finishFirst = resolve;
+      });
+      const second = new Promise<GuardrailResult[]>((resolve) => {
+        finishSecond = resolve;
+      });
+      const check = vi
+        .spyOn(client, 'runStageGuardrails')
+        .mockImplementationOnce(() => first)
+        .mockImplementationOnce(() => {
+          secondStarted();
+          return second;
+        });
+      const original = chunk([
+        [1, 'second choice'],
+        [0, 'first choice'],
+      ]);
+      const iterator = StreamingMixin.streamWithGuardrailsSync(
+        client,
+        stream([original]),
+        [],
+        [],
+        []
+      );
+      await iterator.next();
+      const next = iterator.next();
+      const firstResult: GuardrailResult = { tripwireTriggered: false, info: { text: 'first' } };
+      const secondResult: GuardrailResult = {
+        tripwireTriggered: tripwire,
+        info: { text: 'second' },
+      };
+      try {
+        await started;
+        expect(check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'second choice']);
+        finishSecond([secondResult]);
+        finishFirst([firstResult]);
+        const final = (await next).value;
+        expect(final.guardrail_results.output).toEqual([firstResult, secondResult]);
+        if (tripwire) {
+          await expect(iterator.next()).rejects.toMatchObject({ guardrailResult: secondResult });
+        } else {
+          expect((await iterator.next()).done).toBe(true);
+        }
+      } finally {
+        finishFirst([]);
+        finishSecond([]);
+        await iterator.return(undefined);
       }
-    } finally {
-      finishFirst([]);
-      finishSecond([]);
-      await iterator.return(undefined);
     }
-  });
-
+  );
 
   it('starts non-streaming choice checks concurrently and preserves result order', async () => {
     const client = new ChoiceClient();
     let finishFirst!: (results: GuardrailResult[]) => void;
-    const first = new Promise<GuardrailResult[]>((resolve) => { finishFirst = resolve; });
+    const first = new Promise<GuardrailResult[]>((resolve) => {
+      finishFirst = resolve;
+    });
     const firstResult: GuardrailResult = { tripwireTriggered: false, info: { text: 'first' } };
     const secondResult: GuardrailResult = { tripwireTriggered: false, info: { text: 'second' } };
-    const check = vi.spyOn(client, 'runStageGuardrails')
+    const check = vi
+      .spyOn(client, 'runStageGuardrails')
       .mockImplementationOnce(() => first)
       .mockResolvedValueOnce([secondResult]);
     const response = client.handle(completion(['first choice', 'second choice']));
@@ -219,43 +431,114 @@ describe('Chat choice validation', () => {
       expect(check).toHaveBeenCalledTimes(2);
       finishFirst([firstResult]);
       expect((await response).guardrail_results.output).toEqual([firstResult, secondResult]);
-    } finally { finishFirst([]); }
-  });
-
-  it.each([false, true])('preserves strict multi-choice execution errors (streaming=%s)', async (streaming) => {
-    const client = new ChoiceClient();
-    client.raiseGuardrailErrors = true;
-    const error = new GuardrailTripwireTriggered({ tripwireTriggered: true, info: {} });
-    client.check.mockImplementation((_context, text) => {
-      if (text === 'second choice') throw error;
-      return { tripwireTriggered: false, info: {} };
-    });
-    if (!streaming) {
-      await expect(client.handle(completion(['first choice', 'second choice']), true)).rejects.toBe(error);
-    } else {
-      const iterator = StreamingMixin.streamWithGuardrailsSync(client, stream([
-        chunk([[0, 'first choice'], [1, 'second choice']]),
-      ]), [], [], [], true);
-      await iterator.next();
-      // An execution error that is itself a tripwire must not produce final diagnostics.
-      await expect(iterator.next()).rejects.toBe(error);
+    } finally {
+      finishFirst([]);
     }
   });
 
+  it.each([false, true])(
+    'preserves strict multi-choice execution errors (streaming=%s)',
+    async (streaming) => {
+      const client = new ChoiceClient();
+      client.raiseGuardrailErrors = true;
+      const error = new GuardrailTripwireTriggered({ tripwireTriggered: true, info: {} });
+      client.check.mockImplementation((_context, text) => {
+        if (text === 'second choice') throw error;
+        return { tripwireTriggered: false, info: {} };
+      });
+      if (!streaming) {
+        await expect(
+          client.handle(completion(['first choice', 'second choice']), true)
+        ).rejects.toBe(error);
+      } else {
+        const iterator = StreamingMixin.streamWithGuardrailsSync(
+          client,
+          stream([
+            chunk([
+              [0, 'first choice'],
+              [1, 'second choice'],
+            ]),
+          ]),
+          [],
+          [],
+          [],
+          true
+        );
+        await iterator.next();
+        // An execution error that is itself a tripwire must not produce final diagnostics.
+        await expect(iterator.next()).rejects.toBe(error);
+      }
+    }
+  );
 
   it('prioritizes a delayed strict execution error over an earlier tripwire', async () => {
     const client = new ChoiceClient();
     client.raiseGuardrailErrors = true;
     const error = new Error('fixture execution failure');
     let finishSecond!: (results: GuardrailResult[]) => void;
-    const second = new Promise<GuardrailResult[]>((resolve) => { finishSecond = resolve; });
-    const check = vi.spyOn(client, 'runStageGuardrails')
+    const second = new Promise<GuardrailResult[]>((resolve) => {
+      finishSecond = resolve;
+    });
+    const check = vi
+      .spyOn(client, 'runStageGuardrails')
       .mockResolvedValueOnce([{ tripwireTriggered: true, info: {} }])
       .mockImplementationOnce(() => second);
     const response = client.handle(completion(['first choice', 'second choice']));
-    expect(check.mock.calls.map((call) => call.slice(3))).toEqual([[true, false], [true, false]]);
-    finishSecond([{ tripwireTriggered: false, executionFailed: true, originalException: error, info: {} }]);
+    expect(check.mock.calls.map((call) => call.slice(3))).toEqual([
+      [true, false],
+      [true, false],
+    ]);
+    finishSecond([
+      { tripwireTriggered: false, executionFailed: true, originalException: error, info: {} },
+    ]);
     await expect(response).rejects.toBe(error);
   });
 
+  it.each([false, true])(
+    'validates textless alternatives with empty-output guardrails (suppressed=%s)',
+    async (suppressed) => {
+      const client = new ChoiceClient();
+      client.check.mockImplementation((_context, text) => ({
+        tripwireTriggered: text === '',
+        info: { text },
+      }));
+      const iterator = StreamingMixin.streamWithGuardrailsSync(
+        client,
+        stream([
+          chunk([
+            [1, null],
+            [0, 'first choice'],
+          ]),
+          chunk([[1, '']]),
+          chunk([]),
+        ]),
+        [],
+        [],
+        [],
+        suppressed
+      );
+      if (suppressed) {
+        const responses = await collect(iterator);
+        expect(
+          responses.at(-1)?.guardrail_results.output.map((result) => result.info.text)
+        ).toEqual(['first choice', '']);
+        expect(responses.at(-1)?.guardrail_results.tripwiresTriggered).toBe(true);
+      } else {
+        await expect(collect(iterator)).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
+      }
+      expect(client.check.mock.calls.map(([, text]) => text)).toEqual(['first choice', '']);
+    }
+  );
+
+  it('validates a single textless Chat choice at EOF', async () => {
+    const client = new ChoiceClient();
+    client.check.mockImplementation((_context, text) => ({
+      tripwireTriggered: text === '',
+      info: {},
+    }));
+    await expect(
+      collect(StreamingMixin.streamWithGuardrailsSync(client, stream([chunk([[0, null]])]), [], []))
+    ).rejects.toBeInstanceOf(GuardrailTripwireTriggered);
+    expect(client.check).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/__tests__/unit/additional-choices.test.ts
+++ b/src/__tests__/unit/additional-choices.test.ts
@@ -172,11 +172,10 @@ describe('Chat choice validation', () => {
     const client = new ChoiceClient();
     let finishFirst!: (results: GuardrailResult[]) => void;
     let finishSecond!: (results: GuardrailResult[]) => void;
-    let rejectSecond!: (error: Error) => void;
     let secondStarted!: () => void;
     const started = new Promise<void>((resolve) => { secondStarted = resolve; });
     const first = new Promise<GuardrailResult[]>((resolve) => { finishFirst = resolve; });
-    const second = new Promise<GuardrailResult[]>((resolve, reject) => { finishSecond = resolve; rejectSecond = reject; });
+    const second = new Promise<GuardrailResult[]>((resolve) => { finishSecond = resolve; });
     const check = vi.spyOn(client, 'runStageGuardrails')
       .mockImplementationOnce(() => first)
       .mockImplementationOnce(() => { secondStarted(); return second; });
@@ -186,16 +185,15 @@ describe('Chat choice validation', () => {
     const next = iterator.next();
     const firstResult: GuardrailResult = { tripwireTriggered: false, info: { text: 'first' } };
     const secondResult: GuardrailResult = { tripwireTriggered: tripwire, info: { text: 'second' } };
-    const error = new GuardrailTripwireTriggered(secondResult);
     try {
       await started;
       expect(check.mock.calls.map(([, text]) => text)).toEqual(['first choice', 'second choice']);
-      if (tripwire) { rejectSecond(error); } else { finishSecond([secondResult]); }
+      finishSecond([secondResult]);
       finishFirst([firstResult]);
       const final = (await next).value;
       expect(final.guardrail_results.output).toEqual([firstResult, secondResult]);
       if (tripwire) {
-        await expect(iterator.next()).rejects.toBe(error);
+        await expect(iterator.next()).rejects.toMatchObject({ guardrailResult: secondResult });
       } else {
         expect((await iterator.next()).done).toBe(true);
       }
@@ -204,6 +202,60 @@ describe('Chat choice validation', () => {
       finishSecond([]);
       await iterator.return(undefined);
     }
+  });
+
+
+  it('starts non-streaming choice checks concurrently and preserves result order', async () => {
+    const client = new ChoiceClient();
+    let finishFirst!: (results: GuardrailResult[]) => void;
+    const first = new Promise<GuardrailResult[]>((resolve) => { finishFirst = resolve; });
+    const firstResult: GuardrailResult = { tripwireTriggered: false, info: { text: 'first' } };
+    const secondResult: GuardrailResult = { tripwireTriggered: false, info: { text: 'second' } };
+    const check = vi.spyOn(client, 'runStageGuardrails')
+      .mockImplementationOnce(() => first)
+      .mockResolvedValueOnce([secondResult]);
+    const response = client.handle(completion(['first choice', 'second choice']));
+    try {
+      expect(check).toHaveBeenCalledTimes(2);
+      finishFirst([firstResult]);
+      expect((await response).guardrail_results.output).toEqual([firstResult, secondResult]);
+    } finally { finishFirst([]); }
+  });
+
+  it.each([false, true])('preserves strict multi-choice execution errors (streaming=%s)', async (streaming) => {
+    const client = new ChoiceClient();
+    client.raiseGuardrailErrors = true;
+    const error = new GuardrailTripwireTriggered({ tripwireTriggered: true, info: {} });
+    client.check.mockImplementation((_context, text) => {
+      if (text === 'second choice') throw error;
+      return { tripwireTriggered: false, info: {} };
+    });
+    if (!streaming) {
+      await expect(client.handle(completion(['first choice', 'second choice']), true)).rejects.toBe(error);
+    } else {
+      const iterator = StreamingMixin.streamWithGuardrailsSync(client, stream([
+        chunk([[0, 'first choice'], [1, 'second choice']]),
+      ]), [], [], [], true);
+      await iterator.next();
+      // An execution error that is itself a tripwire must not produce final diagnostics.
+      await expect(iterator.next()).rejects.toBe(error);
+    }
+  });
+
+
+  it('prioritizes a delayed strict execution error over an earlier tripwire', async () => {
+    const client = new ChoiceClient();
+    client.raiseGuardrailErrors = true;
+    const error = new Error('fixture execution failure');
+    let finishSecond!: (results: GuardrailResult[]) => void;
+    const second = new Promise<GuardrailResult[]>((resolve) => { finishSecond = resolve; });
+    const check = vi.spyOn(client, 'runStageGuardrails')
+      .mockResolvedValueOnce([{ tripwireTriggered: true, info: {} }])
+      .mockImplementationOnce(() => second);
+    const response = client.handle(completion(['first choice', 'second choice']));
+    expect(check.mock.calls.map((call) => call.slice(3))).toEqual([[true, false], [true, false]]);
+    finishSecond([{ tripwireTriggered: false, executionFailed: true, originalException: error, info: {} }]);
+    await expect(response).rejects.toBe(error);
   });
 
 });

--- a/src/__tests__/unit/base-client.test.ts
+++ b/src/__tests__/unit/base-client.test.ts
@@ -420,7 +420,7 @@ describe('GuardrailsBaseClient helpers', () => {
           { role: 'user', content: 'hi' },
           { role: 'assistant', content: 'All good' },
         ]),
-        false,
+        true,
         false
       );
       expect(

--- a/src/__tests__/unit/output-error-policy.test.ts
+++ b/src/__tests__/unit/output-error-policy.test.ts
@@ -10,7 +10,7 @@ import { StreamingMixin } from '../../streaming';
 import type { GuardrailLLMContext, GuardrailResult } from '../../types';
 
 class OutputTestClient extends GuardrailsBaseClient {
-  constructor(check: () => GuardrailResult, strict: boolean | undefined) {
+  constructor(check: () => GuardrailResult | Promise<GuardrailResult>, strict: boolean | undefined) {
     super();
     const registry = new GuardrailRegistry();
     registry.register('Output fixture', vi.fn(check), 'Inert output check');
@@ -296,4 +296,37 @@ describe('output execution-error policy', () => {
     await expect(iterator.next()).rejects.toBe(error);
     expect(check).toHaveBeenCalledTimes(2);
   });
+
+  it('does not mark a pending check strict when its result is accepted non-strictly', async () => {
+    const error = new Error('Inert pending check failure');
+    const result: GuardrailResult = {
+      tripwireTriggered: false, executionFailed: true, originalException: error, info: {},
+    };
+    let finish!: (result: GuardrailResult) => void;
+    const pending = new Promise<GuardrailResult>((resolve) => { finish = resolve; });
+    let started!: () => void;
+    const checkStarted = new Promise<void>((resolve) => { started = resolve; });
+    const check = vi.fn<() => GuardrailResult | Promise<GuardrailResult>>()
+      .mockImplementationOnce(() => { started(); return pending; })
+      .mockReturnValue(result);
+    const client = new OutputTestClient(check, true);
+    async function* chunks() {
+      yield { type: 'response.output_text.delta', delta: 'Hello' };
+    }
+    const iterator = new StreamingMixin().streamWithGuardrails.call(client, chunks(), [], [], [], 1, true);
+    const next = iterator.next();
+    try {
+      await checkStarted;
+      client.raiseGuardrailErrors = false;
+      finish(result);
+      expect((await next).done).toBe(false);
+      client.raiseGuardrailErrors = true;
+      await expect(iterator.next()).rejects.toBe(error);
+      expect(check).toHaveBeenCalledTimes(2);
+    } finally {
+      finish(result);
+      await iterator.return(undefined);
+    }
+  });
+
 });

--- a/src/__tests__/unit/output-error-policy.test.ts
+++ b/src/__tests__/unit/output-error-policy.test.ts
@@ -10,7 +10,10 @@ import { StreamingMixin } from '../../streaming';
 import type { GuardrailLLMContext, GuardrailResult } from '../../types';
 
 class OutputTestClient extends GuardrailsBaseClient {
-  constructor(check: () => GuardrailResult | Promise<GuardrailResult>, strict: boolean | undefined) {
+  constructor(
+    check: () => GuardrailResult | Promise<GuardrailResult>,
+    strict: boolean | undefined
+  ) {
     super();
     const registry = new GuardrailRegistry();
     registry.register('Output fixture', vi.fn(check), 'Inert output check');
@@ -300,20 +303,39 @@ describe('output execution-error policy', () => {
   it('does not mark a pending check strict when its result is accepted non-strictly', async () => {
     const error = new Error('Inert pending check failure');
     const result: GuardrailResult = {
-      tripwireTriggered: false, executionFailed: true, originalException: error, info: {},
+      tripwireTriggered: false,
+      executionFailed: true,
+      originalException: error,
+      info: {},
     };
     let finish!: (result: GuardrailResult) => void;
-    const pending = new Promise<GuardrailResult>((resolve) => { finish = resolve; });
+    const pending = new Promise<GuardrailResult>((resolve) => {
+      finish = resolve;
+    });
     let started!: () => void;
-    const checkStarted = new Promise<void>((resolve) => { started = resolve; });
-    const check = vi.fn<() => GuardrailResult | Promise<GuardrailResult>>()
-      .mockImplementationOnce(() => { started(); return pending; })
+    const checkStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const check = vi
+      .fn<() => GuardrailResult | Promise<GuardrailResult>>()
+      .mockImplementationOnce(() => {
+        started();
+        return pending;
+      })
       .mockReturnValue(result);
     const client = new OutputTestClient(check, true);
     async function* chunks() {
       yield { type: 'response.output_text.delta', delta: 'Hello' };
     }
-    const iterator = new StreamingMixin().streamWithGuardrails.call(client, chunks(), [], [], [], 1, true);
+    const iterator = new StreamingMixin().streamWithGuardrails.call(
+      client,
+      chunks(),
+      [],
+      [],
+      [],
+      1,
+      true
+    );
     const next = iterator.next();
     try {
       await checkStarted;
@@ -328,5 +350,4 @@ describe('output execution-error policy', () => {
       await iterator.return(undefined);
     }
   });
-
 });

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -333,6 +333,10 @@ export abstract class GuardrailsBaseClient {
     if ('choices' in response && response.choices) {
       const choice0 = response.choices[0];
 
+      if (!choice0) {
+        return '';
+      }
+
       if ('message' in choice0 && choice0.message) {
         return choice0.message.content || '';
       }
@@ -629,19 +633,20 @@ export abstract class GuardrailsBaseClient {
       conversationHistory !== undefined && conversationHistory !== null
         ? this.normalizeConversationHistory(conversationHistory)
         : [];
-    const completeConversation = this.appendLlmResponseToConversation(
-      normalizedHistory,
-      llmResponse
-    );
-
-    const responseText = this.extractResponseText(llmResponse);
-    const outputResults = await this.runStageGuardrails(
-      'output',
-      responseText,
-      completeConversation,
-      suppressTripwire,
-      this.raiseGuardrailErrors
-    );
+    // Alternatives are separate assistant responses, not consecutive conversation turns.
+    const responses = 'choices' in llmResponse && llmResponse.choices.length > 0
+      ? llmResponse.choices.map((choice) => ({ ...llmResponse, choices: [choice] } as OpenAIResponseType))
+      : [llmResponse];
+    const outputResults: GuardrailResult[] = [];
+    for (const response of responses) {
+      const completeConversation = this.appendLlmResponseToConversation(normalizedHistory, response);
+      outputResults.push(...await this.runStageGuardrails(
+        'output',
+        this.extractResponseText(response),
+        completeConversation,
+        suppressTripwire
+      ));
+    }
 
     return this.createGuardrailsResponse(
       llmResponse,

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -634,19 +634,27 @@ export abstract class GuardrailsBaseClient {
         ? this.normalizeConversationHistory(conversationHistory)
         : [];
     // Alternatives are separate assistant responses, not consecutive conversation turns.
-    const responses = 'choices' in llmResponse && llmResponse.choices.length > 0
-      ? llmResponse.choices.map((choice) => ({ ...llmResponse, choices: [choice] } as OpenAIResponseType))
-      : [llmResponse];
-    const resultsByChoice = await Promise.all(responses.map((response) => {
-      const completeConversation = this.appendLlmResponseToConversation(normalizedHistory, response);
-      return this.runStageGuardrails(
-        'output',
-        this.extractResponseText(response),
-        completeConversation,
-        true,
-        false
-      );
-    }));
+    const responses =
+      'choices' in llmResponse && llmResponse.choices.length > 0
+        ? llmResponse.choices.map(
+            (choice) => ({ ...llmResponse, choices: [choice] }) as OpenAIResponseType
+          )
+        : [llmResponse];
+    const resultsByChoice = await Promise.all(
+      responses.map((response) => {
+        const completeConversation = this.appendLlmResponseToConversation(
+          normalizedHistory,
+          response
+        );
+        return this.runStageGuardrails(
+          'output',
+          this.extractResponseText(response),
+          completeConversation,
+          true,
+          false
+        );
+      })
+    );
     const outputResults = resultsByChoice.flat();
     const failure = getGuardrailFailure(outputResults, suppressTripwire, this.raiseGuardrailErrors);
     if (failure) throw failure.error;

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -637,16 +637,19 @@ export abstract class GuardrailsBaseClient {
     const responses = 'choices' in llmResponse && llmResponse.choices.length > 0
       ? llmResponse.choices.map((choice) => ({ ...llmResponse, choices: [choice] } as OpenAIResponseType))
       : [llmResponse];
-    const outputResults: GuardrailResult[] = [];
-    for (const response of responses) {
+    const resultsByChoice = await Promise.all(responses.map((response) => {
       const completeConversation = this.appendLlmResponseToConversation(normalizedHistory, response);
-      outputResults.push(...await this.runStageGuardrails(
+      return this.runStageGuardrails(
         'output',
         this.extractResponseText(response),
         completeConversation,
-        suppressTripwire
-      ));
-    }
+        true,
+        false
+      );
+    }));
+    const outputResults = resultsByChoice.flat();
+    const failure = getGuardrailFailure(outputResults, suppressTripwire, this.raiseGuardrailErrors);
+    if (failure) throw failure.error;
 
     return this.createGuardrailsResponse(
       llmResponse,

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -42,6 +42,7 @@ export class StreamingMixin {
         hasMultipleChoices = true;
       }
       const periodicChecks: Promise<GuardrailResult[]>[] = [];
+      const periodicCheckpoints: { state: { lastStrictCheckedTextLength: number }; length: number }[] = [];
       for (const alternative of alternatives) {
         const chunkText = this.extractResponseText(alternative.response);
         if (!chunkText) {
@@ -56,17 +57,14 @@ export class StreamingMixin {
           const history = mergeConversationWithItems(baseHistory, [
             { role: 'assistant', content: state.text },
           ]);
-          const checkedLength = state.text.length;
-          const strict = this.raiseGuardrailErrors;
-          periodicChecks.push(this.runStageGuardrails('output', state.text, history, true, false).then((results) => {
-            if (strict) state.lastStrictCheckedTextLength = checkedLength;
-            return results;
-          }));
+          periodicCheckpoints.push({ state, length: state.text.length });
+          periodicChecks.push(this.runStageGuardrails('output', state.text, history, true, false));
         }
       }
 
       const periodicResults = (await Promise.all(periodicChecks)).flat();
-      const periodicFailure = getGuardrailFailure(periodicResults, suppressTripwire, this.raiseGuardrailErrors);
+      const strict = this.raiseGuardrailErrors;
+      const periodicFailure = getGuardrailFailure(periodicResults, suppressTripwire, strict);
       if (periodicFailure) {
         if (periodicFailure.kind === 'tripwire') {
           yield this.createGuardrailsResponse(
@@ -75,6 +73,12 @@ export class StreamingMixin {
           );
         }
         throw periodicFailure.error;
+      }
+
+      if (strict) {
+        for (const checkpoint of periodicCheckpoints) {
+          checkpoint.state.lastStrictCheckedTextLength = checkpoint.length;
+        }
       }
 
       const response = this.createGuardrailsResponse(

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -5,10 +5,10 @@
  * with periodic guardrail checks.
  */
 
-import type { GuardrailsBaseClient, GuardrailsResponse, OpenAIResponseType } from './base-client';
-import type { GuardrailResult } from './types';
-import { mergeConversationWithItems, type NormalizedConversationEntry } from './utils/conversation';
-import { getGuardrailFailure } from './utils/guardrail-failure';
+import { GuardrailResult } from './types';
+import { GuardrailsResponse, GuardrailsBaseClient, OpenAIResponseType } from './base-client';
+import { GuardrailTripwireTriggered } from './exceptions';
+import { mergeConversationWithItems, NormalizedConversationEntry } from './utils/conversation';
 
 /**
  * Mixin providing streaming functionality for guardrails clients.
@@ -26,44 +26,46 @@ export class StreamingMixin {
     checkInterval: number = 100,
     suppressTripwire: boolean = false
   ): AsyncIterableIterator<GuardrailsResponse> {
-    let accumulatedText = '';
-    let chunkCount = 0;
-    let lastStrictCheckedTextLength = 0;
-    const baseHistory = conversationHistory
-      ? conversationHistory.map((entry) => ({ ...entry }))
-      : [];
+    const choices = new Map<number, { text: string; chunkCount: number }>();
+    const baseHistory = conversationHistory ? conversationHistory.map((entry) => ({ ...entry })) : [];
 
     for await (const chunk of llmStream) {
-      const chunkText = this.extractResponseText(chunk as OpenAIResponseType);
-      if (chunkText) {
-        accumulatedText += chunkText;
-        chunkCount += 1;
+      const responseChunk = chunk as OpenAIResponseType;
+      const alternatives = 'choices' in responseChunk
+        ? responseChunk.choices.map((choice) => ({
+          index: choice.index ?? 0,
+          response: { ...responseChunk, choices: [choice] } as OpenAIResponseType,
+        }))
+        : [{ index: 0, response: responseChunk }];
+      for (const alternative of alternatives) {
+        const chunkText = this.extractResponseText(alternative.response);
+        if (!chunkText) {
+          continue;
+        }
+        const state = choices.get(alternative.index) ?? { text: '', chunkCount: 0 };
+        state.text += chunkText;
+        state.chunkCount += 1;
+        choices.set(alternative.index, state);
 
-        if (chunkCount % checkInterval === 0) {
-          const history = mergeConversationWithItems(baseHistory, [
-            { role: 'assistant', content: accumulatedText },
-          ]);
-          // Collect results first: the original execution error may itself be a tripwire error.
-          const results = await this.runStageGuardrails(
-            'output',
-            accumulatedText,
-            history,
-            true,
-            false
-          );
-          const failure = getGuardrailFailure(results, suppressTripwire, this.raiseGuardrailErrors);
-          if (failure) {
-            if (failure.kind === 'tripwire') {
-              yield this.createGuardrailsResponse(
+        if (state.chunkCount % checkInterval === 0) {
+          try {
+            const history = mergeConversationWithItems(baseHistory, [
+              { role: 'assistant', content: state.text },
+            ]);
+            await this.runStageGuardrails('output', state.text, history, suppressTripwire);
+          } catch (error) {
+            if (error instanceof GuardrailTripwireTriggered) {
+              const finalResponse = this.createGuardrailsResponse(
                 chunk as OpenAIResponseType,
                 preflightResults,
                 inputResults,
-                [failure.error.guardrailResult]
+                [error.guardrailResult]
               );
+              yield finalResponse;
+              throw error;
             }
-            throw failure.error;
+            throw error;
           }
-          if (this.raiseGuardrailErrors) lastStrictCheckedTextLength = accumulatedText.length;
         }
       }
 
@@ -76,42 +78,42 @@ export class StreamingMixin {
       yield response;
     }
 
-    const needsStrictFinalCheck =
-      this.raiseGuardrailErrors && accumulatedText.length > lastStrictCheckedTextLength;
-    if ((!suppressTripwire || needsStrictFinalCheck) && accumulatedText) {
-      const history = mergeConversationWithItems(baseHistory, [
-        { role: 'assistant', content: accumulatedText },
-      ]);
-      const finalOutputResults = await this.runStageGuardrails(
-        'output',
-        accumulatedText,
-        history,
-        true,
-        false
-      );
-      const failure = getGuardrailFailure(
-        finalOutputResults,
-        suppressTripwire,
-        this.raiseGuardrailErrors
-      );
-      if (failure) {
-        if (failure.kind === 'tripwire') {
-          yield this.createGuardrailsResponse(
-            { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
-            preflightResults,
-            inputResults,
-            [failure.error.guardrailResult]
-          );
+    if (choices.size > 0) {
+      // Keep the existing final response shape; results cover every alternative.
+      const accumulatedText = choices.get(0)?.text ?? '';
+      try {
+        const finalOutputResults: GuardrailResult[] = [];
+        for (const state of choices.values()) {
+          const history = mergeConversationWithItems(baseHistory, [
+            { role: 'assistant', content: state.text },
+          ]);
+          finalOutputResults.push(...await this.runStageGuardrails(
+            'output',
+            state.text,
+            history,
+            suppressTripwire
+          ));
         }
-        throw failure.error;
-      }
-      if (!suppressTripwire) {
-        yield this.createGuardrailsResponse(
+
+        const finalResponse = this.createGuardrailsResponse(
           { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
           preflightResults,
           inputResults,
           finalOutputResults
         );
+        yield finalResponse;
+      } catch (error) {
+        if (error instanceof GuardrailTripwireTriggered) {
+          const finalResponse = this.createGuardrailsResponse(
+            { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
+            preflightResults,
+            inputResults,
+            [error.guardrailResult]
+          );
+          yield finalResponse;
+          throw error;
+        }
+        throw error;
       }
     }
   }

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -5,10 +5,10 @@
  * with periodic guardrail checks.
  */
 
-import { GuardrailResult } from './types';
-import { GuardrailsResponse, GuardrailsBaseClient, OpenAIResponseType } from './base-client';
+import type { GuardrailsBaseClient, GuardrailsResponse, OpenAIResponseType } from './base-client';
+import type { GuardrailResult } from './types';
+import { mergeConversationWithItems, type NormalizedConversationEntry } from './utils/conversation';
 import { getGuardrailFailure } from './utils/guardrail-failure';
-import { mergeConversationWithItems, NormalizedConversationEntry } from './utils/conversation';
 
 /**
  * Mixin providing streaming functionality for guardrails clients.
@@ -26,32 +26,48 @@ export class StreamingMixin {
     checkInterval: number = 100,
     suppressTripwire: boolean = false
   ): AsyncIterableIterator<GuardrailsResponse> {
-    const choices = new Map<number, { text: string; chunkCount: number; lastStrictCheckedTextLength: number }>();
+    const choices = new Map<
+      number,
+      { text: string; chunkCount: number; lastStrictCheckedTextLength: number }
+    >();
     let hasMultipleChoices = false;
-    const baseHistory = conversationHistory ? conversationHistory.map((entry) => ({ ...entry })) : [];
+    const baseHistory = conversationHistory
+      ? conversationHistory.map((entry) => ({ ...entry }))
+      : [];
 
     for await (const chunk of llmStream) {
       const responseChunk = chunk as OpenAIResponseType;
-      const alternatives = 'choices' in responseChunk
-        ? responseChunk.choices.map((choice) => ({
-          index: choice.index ?? 0,
-          response: { ...responseChunk, choices: [choice] } as OpenAIResponseType,
-        }))
-        : [{ index: 0, response: responseChunk }];
+      const alternatives =
+        'choices' in responseChunk
+          ? responseChunk.choices.map((choice) => ({
+              index: choice.index ?? 0,
+              response: { ...responseChunk, choices: [choice] } as OpenAIResponseType,
+            }))
+          : [{ index: 0, response: responseChunk }];
       if (alternatives.length > 1 || alternatives.some(({ index }) => index !== 0)) {
         hasMultipleChoices = true;
       }
       const periodicChecks: Promise<GuardrailResult[]>[] = [];
-      const periodicCheckpoints: { state: { lastStrictCheckedTextLength: number }; length: number }[] = [];
+      const periodicCheckpoints: {
+        state: { lastStrictCheckedTextLength: number };
+        length: number;
+      }[] = [];
       for (const alternative of alternatives) {
         const chunkText = this.extractResponseText(alternative.response);
+        if (!chunkText && !('choices' in responseChunk)) {
+          continue;
+        }
+        const state = choices.get(alternative.index) ?? {
+          text: '',
+          chunkCount: 0,
+          lastStrictCheckedTextLength: 0,
+        };
+        choices.set(alternative.index, state);
         if (!chunkText) {
           continue;
         }
-        const state = choices.get(alternative.index) ?? { text: '', chunkCount: 0, lastStrictCheckedTextLength: 0 };
         state.text += chunkText;
         state.chunkCount += 1;
-        choices.set(alternative.index, state);
 
         if (state.chunkCount % checkInterval === 0) {
           const history = mergeConversationWithItems(baseHistory, [
@@ -68,7 +84,9 @@ export class StreamingMixin {
       if (periodicFailure) {
         if (periodicFailure.kind === 'tripwire') {
           yield this.createGuardrailsResponse(
-            chunk as OpenAIResponseType, preflightResults, inputResults,
+            chunk as OpenAIResponseType,
+            preflightResults,
+            inputResults,
             [periodicFailure.error.guardrailResult]
           );
         }
@@ -90,30 +108,44 @@ export class StreamingMixin {
       yield response;
     }
 
-    const finalChoices = [...choices.entries()].sort(([a], [b]) => a - b).filter(([, state]) =>
-      hasMultipleChoices || !suppressTripwire ||
-      (this.raiseGuardrailErrors && state.text.length > state.lastStrictCheckedTextLength)
-    );
+    const finalChoices = [...choices.entries()]
+      .sort(([a], [b]) => a - b)
+      .filter(
+        ([, state]) =>
+          state.chunkCount === 0 ||
+          hasMultipleChoices ||
+          !suppressTripwire ||
+          (this.raiseGuardrailErrors && state.text.length > state.lastStrictCheckedTextLength)
+      );
     if (finalChoices.length > 0) {
       const accumulatedText = choices.get(0)?.text ?? '';
-      const finalOutputResults = (await Promise.all(finalChoices.map(([, state]) => {
-        const history = mergeConversationWithItems(baseHistory, [
-          { role: 'assistant', content: state.text },
-        ]);
-        // Classify results before throwing: execution errors can themselves be tripwire errors.
-        return this.runStageGuardrails('output', state.text, history, true, false);
-      }))).flat();
-      const failure = getGuardrailFailure(finalOutputResults, suppressTripwire, this.raiseGuardrailErrors);
+      const finalOutputResults = (
+        await Promise.all(
+          finalChoices.map(([, state]) => {
+            const history = mergeConversationWithItems(baseHistory, [
+              { role: 'assistant', content: state.text },
+            ]);
+            // Classify results before throwing: execution errors can themselves be tripwire errors.
+            return this.runStageGuardrails('output', state.text, history, true, false);
+          })
+        )
+      ).flat();
+      const failure = getGuardrailFailure(
+        finalOutputResults,
+        suppressTripwire,
+        this.raiseGuardrailErrors
+      );
       if (failure?.kind === 'execution') throw failure.error;
       if (hasMultipleChoices || !suppressTripwire) {
         yield this.createGuardrailsResponse(
           { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
-          preflightResults, inputResults, finalOutputResults
+          preflightResults,
+          inputResults,
+          finalOutputResults
         );
       }
       if (failure) throw failure.error;
     }
-
   }
 
   /**

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -84,39 +84,35 @@ export class StreamingMixin {
     if (choices.size > 0) {
       // Keep the existing final response shape; results cover every alternative.
       const accumulatedText = choices.get(0)?.text ?? '';
-      const finalOutputResults: GuardrailResult[] = [];
-      try {
-        for (const [, state] of [...choices.entries()].sort(([a], [b]) => a - b)) {
+      const settledChecks = await Promise.allSettled(
+        [...choices.entries()].sort(([a], [b]) => a - b).map(([, state]) => {
           const history = mergeConversationWithItems(baseHistory, [
             { role: 'assistant', content: state.text },
           ]);
-          finalOutputResults.push(...await this.runStageGuardrails(
-            'output',
-            state.text,
-            history,
-            suppressTripwire
-          ));
+          return this.runStageGuardrails('output', state.text, history, suppressTripwire);
+        })
+      );
+      const finalOutputResults: GuardrailResult[] = [];
+      for (const check of settledChecks) {
+        if (check.status === 'fulfilled') {
+          finalOutputResults.push(...check.value);
+        } else if (check.reason instanceof GuardrailTripwireTriggered) {
+          finalOutputResults.push(check.reason.guardrailResult);
         }
-
-        const finalResponse = this.createGuardrailsResponse(
-          { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
-          preflightResults,
-          inputResults,
-          finalOutputResults
-        );
-        yield finalResponse;
-      } catch (error) {
-        if (error instanceof GuardrailTripwireTriggered) {
-          const finalResponse = this.createGuardrailsResponse(
-            { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
-            preflightResults,
-            inputResults,
-            [...finalOutputResults, error.guardrailResult]
-          );
-          yield finalResponse;
-          throw error;
-        }
-        throw error;
+      }
+      const failure = settledChecks.find((check) => check.status === 'rejected');
+      if (failure?.status === 'rejected' && !(failure.reason instanceof GuardrailTripwireTriggered)) {
+        throw failure.reason;
+      }
+      const finalResponse = this.createGuardrailsResponse(
+        { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
+        preflightResults,
+        inputResults,
+        finalOutputResults
+      );
+      yield finalResponse;
+      if (failure?.status === 'rejected') {
+        throw failure.reason;
       }
     }
   }

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -37,6 +37,7 @@ export class StreamingMixin {
           response: { ...responseChunk, choices: [choice] } as OpenAIResponseType,
         }))
         : [{ index: 0, response: responseChunk }];
+      const periodicChecks: Promise<GuardrailResult[]>[] = [];
       for (const alternative of alternatives) {
         const chunkText = this.extractResponseText(alternative.response);
         if (!chunkText) {
@@ -48,25 +49,27 @@ export class StreamingMixin {
         choices.set(alternative.index, state);
 
         if (state.chunkCount % checkInterval === 0) {
-          try {
-            const history = mergeConversationWithItems(baseHistory, [
-              { role: 'assistant', content: state.text },
-            ]);
-            await this.runStageGuardrails('output', state.text, history, suppressTripwire);
-          } catch (error) {
-            if (error instanceof GuardrailTripwireTriggered) {
-              const finalResponse = this.createGuardrailsResponse(
-                chunk as OpenAIResponseType,
-                preflightResults,
-                inputResults,
-                [error.guardrailResult]
-              );
-              yield finalResponse;
-              throw error;
-            }
-            throw error;
-          }
+          const history = mergeConversationWithItems(baseHistory, [
+            { role: 'assistant', content: state.text },
+          ]);
+          periodicChecks.push(this.runStageGuardrails('output', state.text, history, suppressTripwire));
         }
+      }
+
+      try {
+        await Promise.all(periodicChecks);
+      } catch (error) {
+        if (error instanceof GuardrailTripwireTriggered) {
+          const finalResponse = this.createGuardrailsResponse(
+            chunk as OpenAIResponseType,
+            preflightResults,
+            inputResults,
+            [error.guardrailResult]
+          );
+          yield finalResponse;
+          throw error;
+        }
+        throw error;
       }
 
       const response = this.createGuardrailsResponse(
@@ -81,9 +84,9 @@ export class StreamingMixin {
     if (choices.size > 0) {
       // Keep the existing final response shape; results cover every alternative.
       const accumulatedText = choices.get(0)?.text ?? '';
+      const finalOutputResults: GuardrailResult[] = [];
       try {
-        const finalOutputResults: GuardrailResult[] = [];
-        for (const state of choices.values()) {
+        for (const [, state] of [...choices.entries()].sort(([a], [b]) => a - b)) {
           const history = mergeConversationWithItems(baseHistory, [
             { role: 'assistant', content: state.text },
           ]);
@@ -108,7 +111,7 @@ export class StreamingMixin {
             { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
             preflightResults,
             inputResults,
-            [error.guardrailResult]
+            [...finalOutputResults, error.guardrailResult]
           );
           yield finalResponse;
           throw error;

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -7,7 +7,7 @@
 
 import { GuardrailResult } from './types';
 import { GuardrailsResponse, GuardrailsBaseClient, OpenAIResponseType } from './base-client';
-import { GuardrailTripwireTriggered } from './exceptions';
+import { getGuardrailFailure } from './utils/guardrail-failure';
 import { mergeConversationWithItems, NormalizedConversationEntry } from './utils/conversation';
 
 /**
@@ -26,7 +26,8 @@ export class StreamingMixin {
     checkInterval: number = 100,
     suppressTripwire: boolean = false
   ): AsyncIterableIterator<GuardrailsResponse> {
-    const choices = new Map<number, { text: string; chunkCount: number }>();
+    const choices = new Map<number, { text: string; chunkCount: number; lastStrictCheckedTextLength: number }>();
+    let hasMultipleChoices = false;
     const baseHistory = conversationHistory ? conversationHistory.map((entry) => ({ ...entry })) : [];
 
     for await (const chunk of llmStream) {
@@ -37,13 +38,16 @@ export class StreamingMixin {
           response: { ...responseChunk, choices: [choice] } as OpenAIResponseType,
         }))
         : [{ index: 0, response: responseChunk }];
+      if (alternatives.length > 1 || alternatives.some(({ index }) => index !== 0)) {
+        hasMultipleChoices = true;
+      }
       const periodicChecks: Promise<GuardrailResult[]>[] = [];
       for (const alternative of alternatives) {
         const chunkText = this.extractResponseText(alternative.response);
         if (!chunkText) {
           continue;
         }
-        const state = choices.get(alternative.index) ?? { text: '', chunkCount: 0 };
+        const state = choices.get(alternative.index) ?? { text: '', chunkCount: 0, lastStrictCheckedTextLength: 0 };
         state.text += chunkText;
         state.chunkCount += 1;
         choices.set(alternative.index, state);
@@ -52,24 +56,25 @@ export class StreamingMixin {
           const history = mergeConversationWithItems(baseHistory, [
             { role: 'assistant', content: state.text },
           ]);
-          periodicChecks.push(this.runStageGuardrails('output', state.text, history, suppressTripwire));
+          const checkedLength = state.text.length;
+          const strict = this.raiseGuardrailErrors;
+          periodicChecks.push(this.runStageGuardrails('output', state.text, history, true, false).then((results) => {
+            if (strict) state.lastStrictCheckedTextLength = checkedLength;
+            return results;
+          }));
         }
       }
 
-      try {
-        await Promise.all(periodicChecks);
-      } catch (error) {
-        if (error instanceof GuardrailTripwireTriggered) {
-          const finalResponse = this.createGuardrailsResponse(
-            chunk as OpenAIResponseType,
-            preflightResults,
-            inputResults,
-            [error.guardrailResult]
+      const periodicResults = (await Promise.all(periodicChecks)).flat();
+      const periodicFailure = getGuardrailFailure(periodicResults, suppressTripwire, this.raiseGuardrailErrors);
+      if (periodicFailure) {
+        if (periodicFailure.kind === 'tripwire') {
+          yield this.createGuardrailsResponse(
+            chunk as OpenAIResponseType, preflightResults, inputResults,
+            [periodicFailure.error.guardrailResult]
           );
-          yield finalResponse;
-          throw error;
         }
-        throw error;
+        throw periodicFailure.error;
       }
 
       const response = this.createGuardrailsResponse(
@@ -81,40 +86,30 @@ export class StreamingMixin {
       yield response;
     }
 
-    if (choices.size > 0) {
-      // Keep the existing final response shape; results cover every alternative.
+    const finalChoices = [...choices.entries()].sort(([a], [b]) => a - b).filter(([, state]) =>
+      hasMultipleChoices || !suppressTripwire ||
+      (this.raiseGuardrailErrors && state.text.length > state.lastStrictCheckedTextLength)
+    );
+    if (finalChoices.length > 0) {
       const accumulatedText = choices.get(0)?.text ?? '';
-      const settledChecks = await Promise.allSettled(
-        [...choices.entries()].sort(([a], [b]) => a - b).map(([, state]) => {
-          const history = mergeConversationWithItems(baseHistory, [
-            { role: 'assistant', content: state.text },
-          ]);
-          return this.runStageGuardrails('output', state.text, history, suppressTripwire);
-        })
-      );
-      const finalOutputResults: GuardrailResult[] = [];
-      for (const check of settledChecks) {
-        if (check.status === 'fulfilled') {
-          finalOutputResults.push(...check.value);
-        } else if (check.reason instanceof GuardrailTripwireTriggered) {
-          finalOutputResults.push(check.reason.guardrailResult);
-        }
+      const finalOutputResults = (await Promise.all(finalChoices.map(([, state]) => {
+        const history = mergeConversationWithItems(baseHistory, [
+          { role: 'assistant', content: state.text },
+        ]);
+        // Classify results before throwing: execution errors can themselves be tripwire errors.
+        return this.runStageGuardrails('output', state.text, history, true, false);
+      }))).flat();
+      const failure = getGuardrailFailure(finalOutputResults, suppressTripwire, this.raiseGuardrailErrors);
+      if (failure?.kind === 'execution') throw failure.error;
+      if (hasMultipleChoices || !suppressTripwire) {
+        yield this.createGuardrailsResponse(
+          { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
+          preflightResults, inputResults, finalOutputResults
+        );
       }
-      const failure = settledChecks.find((check) => check.status === 'rejected');
-      if (failure?.status === 'rejected' && !(failure.reason instanceof GuardrailTripwireTriggered)) {
-        throw failure.reason;
-      }
-      const finalResponse = this.createGuardrailsResponse(
-        { type: 'final', accumulated_text: accumulatedText } as unknown as OpenAIResponseType,
-        preflightResults,
-        inputResults,
-        finalOutputResults
-      );
-      yield finalResponse;
-      if (failure?.status === 'rejected') {
-        throw failure.reason;
-      }
+      if (failure) throw failure.error;
     }
+
   }
 
   /**


### PR DESCRIPTION
## Summary

Chat completions requesting multiple alternatives previously ran output checks only on the first choice. Validate each choice independently with its own conversation context, and track streamed text and periodic checks by choice index.

Keep all original choices and chunks, supported `n` requests, public signatures, and the default streaming interval. Output results remain a flat array. Multi-choice streams now run final checks even with `suppressTripwire`, returning the existing final-results shape without raising tripwire exceptions. Streaming retains its documented immediate-delivery behavior.

## Validation

- 722 tests passed, including 20 inert regression cases for later choices, independent histories, reordered/interleaved chunks, suppression, and textless/usage-only chunks.
- Streaming regressions also verify choice-index result order, concurrent periodic and final checks, and retained final diagnostics/token usage when a later choice trips.
- Rebased onto main while preserving strict execution-error provenance and single-choice suppression behavior; non-streaming checks also run concurrently.
- Mutable strict-mode regression verifies a pending check accepted non-strictly is rechecked at EOF when strict mode is restored.
- Real-runner regressions cover textless alternatives with empty-output guardrails, including suppression and a single empty choice.
- Eight mocked-provider checks passed across OpenAI/Azure, streaming/non-streaming, and suppression settings; no network calls.
- Build, Biome, docs build/checks, and `npm pack --dry-run` passed.
- Two independent reviewers per adversarial review round, with two consecutive clean rounds; security and compatibility review included.






