### PR TITLE
ci: schedule Dependabot updates with an eight-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Includes SDK dependencies and the VitePress documentation tooling.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    # Routine version updates wait eight days; security updates are exempt.
+    cooldown:
+      default-days: 8
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    cooldown:
+      default-days: 8


### PR DESCRIPTION
## Summary

The repository has release-PR automation but no routine dependency-update schedule. Add Dependabot checks every Monday for root npm dependencies (including VitePress docs tooling) and GitHub Actions, with an eight-day cooldown for routine version updates. Dependabot security updates remain exempt from the cooldown.

## Validation

- YAML parsing and policy assertions; Prettier check; git diff --check.
- TypeScript build, 519 tests, and ESLint passed (two preexisting unused-suppression warnings).
- Two consecutive clean adversarial-review rounds, with two independent fresh-context read-only reviewers per round; supply-chain security configuration reviewed.

The schedule becomes active after this configuration merges to the default branch.
