### PR TITLE
fix: reject control-obfuscated URL scheme prefixes

### DIFF
--- a/.changeset/quiet-urls-report.md
+++ b/.changeset/quiet-urls-report.md
@@ -1,0 +1,8 @@
+---
+'@openai/guardrails': patch
+---
+
+The URL Filter now rejects `http`, `https`, `ftp`, `data`, `javascript`, and
+`vbscript` scheme prefixes containing embedded TAB, LF, or CR characters,
+including when the destination is allowlisted. These ambiguous prefixes are
+reported in `detected` and `blocked` with their original control characters.

--- a/.changeset/quiet-urls-report.md
+++ b/.changeset/quiet-urls-report.md
@@ -3,6 +3,8 @@
 ---
 
 The URL Filter now rejects `http`, `https`, `ftp`, `data`, `javascript`, and
-`vbscript` scheme prefixes containing embedded TAB, LF, or CR characters,
+`vbscript` URL scheme prefixes containing embedded TAB, LF, or CR characters,
 including when the destination is allowlisted. These ambiguous prefixes are
 reported in `detected` and `blocked` with their original control characters.
+Ordinary prose labels and scheme-like words inside existing URLs retain their
+previous handling.

--- a/docs/ref/checks/urls.md
+++ b/docs/ref/checks/urls.md
@@ -15,7 +15,10 @@ Advanced URL detection and filtering guardrail that prevents access to unauthori
 ### Control characters and scope
 
 The filter rejects `http`, `https`, `ftp`, `data`, `javascript`, and `vbscript`
-scheme prefixes with TAB, LF, or CR between their letters or before the colon.
+scheme prefixes with TAB, LF, or CR between their letters or before the colon
+when a URL-like continuation immediately follows: `//` and URL content for
+`http`, `https`, and `ftp`, or non-whitespace content for the other three schemes.
+Scheme-like words inside an already-detected URL retain the existing handling.
 WHATWG URL parsers remove those characters, so ordinary whitespace-based
 detection could otherwise miss the scheme. The original prefix is reported in
 `detected` and `blocked` with an ambiguous-scheme reason, even if its destination

--- a/docs/ref/checks/urls.md
+++ b/docs/ref/checks/urls.md
@@ -12,6 +12,25 @@ Advanced URL detection and filtering guardrail that prevents access to unauthori
 
 ## Configuration
 
+### Control characters and scope
+
+The filter rejects `http`, `https`, `ftp`, `data`, `javascript`, and `vbscript`
+scheme prefixes with TAB, LF, or CR between their letters or before the colon.
+WHATWG URL parsers remove those characters, so ordinary whitespace-based
+detection could otherwise miss the scheme. The original prefix is reported in
+`detected` and `blocked` with an ambiguous-scheme reason, even if its destination
+or scheme would otherwise be allowed. Ordinary line breaks between URLs or prose
+remain text boundaries.
+
+This check scans URLs in text; it does not validate every possible interpretation
+of the entire input as one URL. In particular, this scheme-prefix fix does not
+change handling of control characters in hosts, paths, queries, or fragments.
+Applications making network requests must separately validate the exact URL they
+will request, including redirect destinations and resolved addresses. Passing
+this text filter alone is not an SSRF-prevention guarantee.
+
+### Example
+
 ```json
 {
     "name": "URL Filter",

--- a/src/__tests__/unit/checks/url-scheme-controls.test.ts
+++ b/src/__tests__/unit/checks/url-scheme-controls.test.ts
@@ -61,19 +61,25 @@ describe('URL Filter control-bearing scheme prefixes', () => {
     expect(result.info?.blocked).toEqual([]);
   });
 
-  it.each(['example.com/docs/javascript\n:section', '192.0.2.1/docs/data\t:value'])(
-    'keeps scheme-like words inside bare URL paths: %j',
-    async (text) => {
-      const result = await urls(
-        {},
-        text,
-        UrlsConfig.parse({ url_allow_list: ['example.com', '192.0.2.1'] })
-      );
+  it.each([
+    'example.com/docs/javascript\n:section',
+    '192.0.2.1/docs/data\t:value',
+    'example.com?data\t:value',
+    'example.com?next=example.com#data\t:value',
+    'example.com#javascript\n:section',
+    'example.com:8080/docs/data\t:value',
+    'example.com:8080?data\t:value',
+    '192.0.2.1#data\t:value',
+  ])('keeps scheme-like words inside bare URL paths: %j', async (text) => {
+    const result = await urls(
+      {},
+      text,
+      UrlsConfig.parse({ url_allow_list: ['example.com', '192.0.2.1'] })
+    );
 
-      expect(result.tripwireTriggered).toBe(false);
-      expect(result.info?.blocked).toEqual([]);
-    }
-  );
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.blocked).toEqual([]);
+  });
 
   it.each([
     'HTTP\t: Hypertext Transfer Protocol',

--- a/src/__tests__/unit/checks/url-scheme-controls.test.ts
+++ b/src/__tests__/unit/checks/url-scheme-controls.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { UrlsConfig, urls } from '../../../checks/urls';
+
+describe('URL Filter control-bearing scheme prefixes', () => {
+  const config = UrlsConfig.parse({
+    url_allow_list: ['example.com'],
+    allowed_schemes: ['http', 'https', 'ftp', 'data', 'javascript', 'vbscript'],
+  });
+
+  it.each([
+    'h\tttp:',
+    'ht\ntps:',
+    'ft\rp:',
+    'dat\ta:',
+    'java\nscript:',
+    'vbs\rcript:',
+    'HTTPS\t:',
+    'h\t\r\nttp:',
+  ])('rejects ambiguous scheme prefix %j even with an allowed destination', async (prefix) => {
+    const result = await urls({}, `${prefix}//example.com`, config);
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.detected).toContain(prefix);
+    expect(result.info?.blocked).toContain(prefix);
+    expect(result.info?.blocked_reasons).toContain(
+      `${prefix}: Ambiguous URL scheme containing ASCII control characters`
+    );
+  });
+
+  it('reports an ambiguous prefix alongside independent allowed URLs', async () => {
+    const result = await urls(
+      {},
+      'See https://example.com/help and _ht\ttps://example.com',
+      config
+    );
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.blocked).toContain('ht\ttps:');
+    expect(result.info?.allowed).toContain('https://example.com/help');
+  });
+
+  it.each([
+    'See https://example.com and email user@example.com',
+    'See https://example.com for details.\nContact user@example.com',
+    'https://example.com\nhttps://example.com/help',
+    'https://example.com\r\nThen continue',
+    'https://example.com\tmore text',
+    'https://example.com\n',
+  ])('preserves ordinary text boundaries in %j', async (text) => {
+    const result = await urls({}, text, config);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.blocked).toEqual([]);
+    expect(result.info?.allowed).toContain('https://example.com');
+  });
+
+  it('keeps ordinary scheme policy enforcement when text contains line breaks', async () => {
+    const result = await urls(
+      {},
+      'Read this:\nhttp://example.com',
+      UrlsConfig.parse({ url_allow_list: ['example.com'] })
+    );
+
+    expect(result.tripwireTriggered).toBe(true);
+    expect(result.info?.blocked_reasons).toContain('http://example.com: Blocked scheme: http');
+  });
+
+  it.each(['metadata\n: available', 'metadata\t: available', 'metadata\r: available'])(
+    'does not treat scheme-name suffixes in ordinary words as URLs: %j',
+    async (text) => {
+      const result = await urls({}, text, config);
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.info?.detected).toEqual([]);
+    }
+  );
+});

--- a/src/__tests__/unit/checks/url-scheme-controls.test.ts
+++ b/src/__tests__/unit/checks/url-scheme-controls.test.ts
@@ -39,6 +39,55 @@ describe('URL Filter control-bearing scheme prefixes', () => {
     expect(result.info?.allowed).toContain('https://example.com/help');
   });
 
+  it.each(['1', '1.', '+', '-.', '123+.-'])(
+    'preserves the existing URL boundary after prefix %j',
+    async (leading) => {
+      const result = await urls({}, `${leading}https\t://example.com`, config);
+
+      expect(result.tripwireTriggered).toBe(true);
+      expect(result.info?.blocked).toContain('https\t:');
+    }
+  );
+
+  it.each([
+    'https://example.com/docs/javascript\n:section',
+    'https://example.com/search?q=data\t:value',
+    'https://example.com/#data\r:value',
+    'https://example.com/docs/http\t://example.com',
+  ])('keeps a scheme-like word inside an existing URL: %j', async (text) => {
+    const result = await urls({}, text, config);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
+  it.each(['example.com/docs/javascript\n:section', '192.0.2.1/docs/data\t:value'])(
+    'keeps scheme-like words inside bare URL paths: %j',
+    async (text) => {
+      const result = await urls(
+        {},
+        text,
+        UrlsConfig.parse({ url_allow_list: ['example.com', '192.0.2.1'] })
+      );
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.info?.blocked).toEqual([]);
+    }
+  );
+
+  it.each([
+    'HTTP\t: Hypertext Transfer Protocol',
+    'javascript\n: a language label',
+    'ftp\r:',
+    'data\t:',
+    'HTTP\t://',
+  ])('preserves labels without a URL continuation: %j', async (text) => {
+    const result = await urls({}, text, config);
+
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info?.blocked).toEqual([]);
+  });
+
   it.each([
     'See https://example.com and email user@example.com',
     'See https://example.com for details.\nContact user@example.com',

--- a/src/checks/urls.ts
+++ b/src/checks/urls.ts
@@ -21,8 +21,14 @@ const ASCII_URL_CONTROL_RE = /[\t\n\r]/;
 // before whitespace tokenization can discard part of the scheme. Match only
 // the prefix: joining the following text could absorb ordinary prose or email.
 const CONTROL_TOLERANT_SCHEME_RE = new RegExp(
-  `(?<![a-z0-9])(?:${['http', 'https', 'ftp', 'data', 'javascript', 'vbscript']
-    .map((scheme) => [...scheme, ':'].join('[\\t\\n\\r]*'))
+  `(?<![a-z0-9+.-])[0-9+.-]*(${['http', 'https', 'ftp', 'data', 'javascript', 'vbscript']
+    .map(
+      (scheme) =>
+        [...scheme, ':'].join('[\\t\\n\\r]*') +
+        (HOSTLESS_SCHEMES.has(scheme)
+          ? '(?=[^\\s<>"{}|\\\\^`[\\]])'
+          : '(?=//[^\\s<>"{}|\\\\^`[\\]])')
+    )
     .join('|')})`,
   'gi'
 );
@@ -113,14 +119,6 @@ function detectUrls(text: string): string[] {
 
   const detectedUrls: string[] = [];
 
-  if (ASCII_URL_CONTROL_RE.test(text)) {
-    for (const candidate of text.matchAll(CONTROL_TOLERANT_SCHEME_RE)) {
-      if (ASCII_URL_CONTROL_RE.test(candidate[0])) {
-        detectedUrls.push(candidate[0]);
-      }
-    }
-  }
-
   // Pattern 1: URLs with schemes (highest priority)
   // Consume non-letter prefixes at token boundaries without retrying every
   // suffix of a long scheme-like token. The capture retains only the URL.
@@ -138,6 +136,8 @@ function detectUrls(text: string): string[] {
       detectedUrls.push(match);
     }
   }
+
+  const urlRanges: { start: number; end: number }[] = [...schemeRanges];
 
   // Scan bare domains and IPs only outside explicit URL tokens. Matches and
   // ranges are ordered, so each pass advances through the ranges just once.
@@ -164,6 +164,30 @@ function detectUrls(text: string): string[] {
       const match = candidate[0].replace(PUNCTUATION_CLEANUP, '');
       if (match) {
         detectedUrls.push(match);
+        urlRanges.push({ start: candidate.index, end });
+      }
+    }
+  }
+
+  if (ASCII_URL_CONTROL_RE.test(text)) {
+    urlRanges.sort((left, right) => left.start - right.start);
+    let rangeIndex = 0;
+    for (const candidate of text.matchAll(CONTROL_TOLERANT_SCHEME_RE)) {
+      const prefix = candidate[1];
+      const start = candidate.index + candidate[0].length - prefix.length;
+      while (rangeIndex < urlRanges.length && urlRanges[rangeIndex].end <= start) {
+        rangeIndex++;
+      }
+      // A prefix starting inside an existing URL belongs to that URL, even
+      // when its control character extends beyond the whitespace token boundary.
+      // Compare the entire match: a leading numeric/dotted prefix can itself
+      // resemble a bare domain, but does not make this scheme nested URL content.
+      const range = urlRanges[rangeIndex];
+      if (range && range.start < candidate.index) {
+        continue;
+      }
+      if (ASCII_URL_CONTROL_RE.test(prefix)) {
+        detectedUrls.push(prefix);
       }
     }
   }

--- a/src/checks/urls.ts
+++ b/src/checks/urls.ts
@@ -147,6 +147,7 @@ function detectUrls(text: string): string[] {
   ];
   for (const pattern of barePatterns) {
     let rangeIndex = 0;
+    let coveredEnd = 0;
     for (const candidate of text.matchAll(pattern)) {
       while (rangeIndex < schemeRanges.length && schemeRanges[rangeIndex].end <= candidate.index) {
         rangeIndex++;
@@ -164,7 +165,14 @@ function detectUrls(text: string): string[] {
       const match = candidate[0].replace(PUNCTUATION_CLEANUP, '');
       if (match) {
         detectedUrls.push(match);
-        urlRanges.push({ start: candidate.index, end });
+        if (candidate.index >= coveredEnd) {
+          // Extend containment only, leaving extraction and validation unchanged.
+          // Scan each token's query/fragment or port tail once per bare pattern,
+          // even when the same token contains further domain-like matches.
+          const tail = text.slice(end).match(/^(?:[?#]|:\d+(?=[/?#]))[^\s]*/);
+          coveredEnd = end + (tail?.[0].length ?? 0);
+          urlRanges.push({ start: candidate.index, end: coveredEnd });
+        }
       }
     }
   }

--- a/src/checks/urls.ts
+++ b/src/checks/urls.ts
@@ -16,6 +16,16 @@ const DEFAULT_PORTS: Record<string, number> = {
 
 const SCHEME_PREFIX_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 const HOSTLESS_SCHEMES = new Set(['data', 'javascript', 'vbscript', 'mailto']);
+const ASCII_URL_CONTROL_RE = /[\t\n\r]/;
+// WHATWG removes TAB/LF/CR before parsing. Recognize these scheme prefixes
+// before whitespace tokenization can discard part of the scheme. Match only
+// the prefix: joining the following text could absorb ordinary prose or email.
+const CONTROL_TOLERANT_SCHEME_RE = new RegExp(
+  `(?<![a-z0-9])(?:${['http', 'https', 'ftp', 'data', 'javascript', 'vbscript']
+    .map((scheme) => [...scheme, ':'].join('[\\t\\n\\r]*'))
+    .join('|')})`,
+  'gi'
+);
 
 function normalizeAllowedSchemes(value: unknown): Set<string> {
   if (value === undefined || value === null) {
@@ -103,6 +113,14 @@ function detectUrls(text: string): string[] {
 
   const detectedUrls: string[] = [];
 
+  if (ASCII_URL_CONTROL_RE.test(text)) {
+    for (const candidate of text.matchAll(CONTROL_TOLERANT_SCHEME_RE)) {
+      if (ASCII_URL_CONTROL_RE.test(candidate[0])) {
+        detectedUrls.push(candidate[0]);
+      }
+    }
+  }
+
   // Pattern 1: URLs with schemes (highest priority)
   // Consume non-letter prefixes at token boundaries without retrying every
   // suffix of a long scheme-like token. The capture retains only the URL.
@@ -164,6 +182,14 @@ function validateUrlSecurity(
   urlString: string,
   config: UrlsConfig
 ): { parsedUrl: URL | null; reason: string; hadScheme: boolean } {
+  if (ASCII_URL_CONTROL_RE.test(urlString)) {
+    return {
+      parsedUrl: null,
+      reason: 'Ambiguous URL scheme containing ASCII control characters',
+      hadScheme: true,
+    };
+  }
+
   try {
     let parsedUrl: URL;
     let originalScheme: string;


### PR DESCRIPTION
## Problem

The URL Filter tokenizes text on whitespace before parsing detected URLs. TAB,
LF, or CR inside a recognized scheme can therefore hide that scheme from the
filter, while a WHATWG URL consumer removes those characters before parsing.

## Change

Detect control-bearing `http`, `https`, `ftp`, `data`, `javascript`, and
`vbscript` prefixes in the original text and reject them with an
explicit ambiguity reason. Reports preserve the original prefix. A destination
or scheme allowlist cannot override this rejection.

This is a focused alternative to the scheme-detection portion of #68. It keeps
existing extraction and allowlist behavior and does not join URLs with following
prose or email addresses. It does not cover controls in hosts, paths, queries,
or fragments, or provide request-level SSRF protection; those limits are
documented. No public API changes.

Includes a patch changeset and regressions for the recognized schemes, ordinary
prose/email boundaries, consecutive URLs, labels, numeric/punctuation prefixes,
and scheme-like words inside explicit and bare URLs.

## Validation

- Full unit suite: 763 tests passed.
- `npm run build`, `npm run lint`, and `npm run docs:check` passed.
- Two consecutive clean adversarial-review rounds, each with two independent
  read-only reviewers, including static security review.


