### PR TITLE
Upgrade Agents, OpenAI, and Zod together

### DIFF
--- a/.changeset/coordinated-sdk-zod-upgrade.md
+++ b/.changeset/coordinated-sdk-zod-upgrade.md
@@ -5,3 +5,5 @@
 Upgrade to Agents SDK 0.17, OpenAI SDK 7, and Zod 4 together. Custom guardrail schemas must use Zod 4, and applications sharing OpenAI or Agents clients should upgrade those dependencies too. Exported schema definitions, validation errors, and inherited OpenAI APIs now follow their new upstream versions. See the SDK migration guide for native fetch, schema defaults, and inherited API changes.
 
 Preserve built-in LLM output field instructions with Zod 4 and resolve Agents session history through the public SDK entry point, without relying on a hoisted agents-core package. Pipeline JSON and Guardrails factory entry points are unchanged.
+
+Keep default PII entity lists independent across configurations, and preserve API-key callbacks for the separate client used by guardrail checks.

--- a/.changeset/coordinated-sdk-zod-upgrade.md
+++ b/.changeset/coordinated-sdk-zod-upgrade.md
@@ -7,3 +7,5 @@ Upgrade to Agents SDK 0.17, OpenAI SDK 7, and Zod 4 together. Custom guardrail s
 Preserve built-in LLM output field instructions with Zod 4 and resolve Agents session history through the public SDK entry point, without relying on a hoisted agents-core package. Pipeline JSON and Guardrails factory entry points are unchanged.
 
 Keep default PII entity lists independent across configurations, and preserve API-key callbacks for the separate client used by guardrail checks.
+
+Keep Agents preflight checks blocking before model dispatch. Preserve provider and workload-identity authentication for guardrail calls, and retain initialized guardrails and client option overrides when using `withOptions()` on OpenAI or Azure clients.

--- a/.changeset/coordinated-sdk-zod-upgrade.md
+++ b/.changeset/coordinated-sdk-zod-upgrade.md
@@ -1,0 +1,7 @@
+---
+"@openai/guardrails": major
+---
+
+Upgrade to Agents SDK 0.17, OpenAI SDK 7, and Zod 4 together. Custom guardrail schemas must use Zod 4, and applications sharing OpenAI or Agents clients should upgrade those dependencies too. Exported schema definitions, validation errors, and inherited OpenAI APIs now follow their new upstream versions. See the SDK migration guide for native fetch, schema defaults, and inherited API changes.
+
+Preserve built-in LLM output field instructions with Zod 4 and resolve Agents session history through the public SDK entry point, without relying on a hoisted agents-core package. Pipeline JSON and Guardrails factory entry points are unchanged.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,7 @@
 # Quickstart: TypeScript
 
+Upgrading an existing application? See the [SDK migration guide](/sdk_migration/).
+
 Get started with Guardrails TypeScript in minutes. Guardrails provides drop-in replacements for OpenAI clients that automatically validate inputs and outputs using configurable safety checks.
 
 ## Install

--- a/docs/sdk_migration.md
+++ b/docs/sdk_migration.md
@@ -29,8 +29,10 @@ See the [Zod migration guide](https://zod.dev/v4/changelog) for other changes.
 Schema**. Its contents now follow Zod 4 (`type` discriminators instead of Zod 3
 `typeName` values). Consumers that inspect that definition must migrate too.
 
-Built-in LLM checks continue to request JSON objects and validate responses
-locally. Custom fields in their prompt instructions now use Zod 4 wrapper
+Built-in LLM checks use structured outputs for standard output schemas on the
+official OpenAI GPT-4.1 models and their supported snapshots. Other models,
+providers, and custom output schemas retain JSON-object mode. All responses are
+validated locally. Custom fields in prompt instructions now use Zod 4 wrapper
 handling, including preserving array field types.
 
 ## OpenAI and Azure clients
@@ -53,7 +55,7 @@ for all inherited API changes. The Guardrails wrappers still expose their existi
 
 OpenAI's `zodResponseFormat` helper supports Zod 4. Structured output schemas must
 follow the API's required-field rules; use nullable fields for optional values.
-This is separate from the JSON-object mode used by built-in LLM checks.
+Built-in checks use this helper for the structured-output cases described above.
 
 ## Agents integration
 

--- a/docs/sdk_migration.md
+++ b/docs/sdk_migration.md
@@ -57,6 +57,10 @@ OpenAI's `zodResponseFormat` helper supports Zod 4. Structured output schemas mu
 follow the API's required-field rules; use nullable fields for optional values.
 Built-in checks use this helper for the structured-output cases described above.
 
+The separate client used for guardrail checks retains SDK provider and workload-identity
+authentication. `withOptions()` returns an initialized guarded client with the requested
+SDK option overrides, including for Azure clients.
+
 ## Agents integration
 
 Upgrade your application's Agents SDK alongside Guardrails and use Zod 4 for
@@ -68,3 +72,6 @@ Guardrails resolves Runner and guardrail types through the public `@openai/agent
 entry point. Session-backed history no longer depends on npm hoisting the transitive
 `@openai/agents-core` dependency. Input and output guardrails retain conversation
 history when running the built CommonJS package with the matching Agents Runner.
+
+Generated `pre_flight` guardrails explicitly block model dispatch until they pass.
+The `input` stage retains the Agents SDK default execution behavior.

--- a/docs/sdk_migration.md
+++ b/docs/sdk_migration.md
@@ -1,0 +1,68 @@
+# Migrating to Agents 0.17, OpenAI 7, and Zod 4
+
+Guardrails now depends on `@openai/agents ^0.17.2`, `openai ^7.9.0`, and
+`zod ^4.5.4`. Upgrade these together if your application also installs them:
+
+```bash
+npm install @openai/guardrails @openai/agents@^0.17.2 openai@^7.9.0 zod@^4.5.4
+```
+
+The existing Node.js requirement, `^22.13.0 || >=24.0.0`, is unchanged.
+Guardrails pipeline JSON and the `GuardrailAgent.create`, `GuardrailsOpenAI.create`,
+and `GuardrailsAzureOpenAI.create` entry points remain unchanged.
+
+## Custom guardrails and schemas
+
+Use Zod 4 schemas for custom registry configuration, context requirements, and
+LLM output models. Exported built-in schemas and their inferred types now use
+Zod 4; Zod 3 schemas are no longer compatible with these interfaces. Replace
+single-argument records such as `z.record(z.unknown())` with
+`z.record(z.string(), z.unknown())`.
+
+Zod 4 changes validation issue formats and some parsing behavior. Read errors
+through `.issues`, rather than the removed `.errors` alias. Defaults are applied
+inside optional properties; `.default()` returns a default without parsing it.
+Use `.prefault()` if a custom schema must parse or transform its default.
+See the [Zod migration guide](https://zod.dev/v4/changelog) for other changes.
+
+`GuardrailSpec.schema()` still returns the underlying Zod definition, **not JSON
+Schema**. Its contents now follow Zod 4 (`type` discriminators instead of Zod 3
+`typeName` values). Consumers that inspect that definition must migrate too.
+
+Built-in LLM checks continue to request JSON objects and validate responses
+locally. Custom fields in their prompt instructions now use Zod 4 wrapper
+handling, including preserving array field types.
+
+## OpenAI and Azure clients
+
+The wrapped clients, inherited SDK methods, constructor options, request options,
+and response types now follow OpenAI 7. Applications passing their own OpenAI
+client to a guardrail context should upgrade that client too.
+
+OpenAI now uses native Web Fetch types: custom `fetch` implementations must return
+Web `Response` objects, and SDK error headers use `Headers`. Replace `httpAgent`
+configuration with supported `fetchOptions`. Azure-specific options still go to
+`AzureOpenAI`; OpenAI-only provider routing options are not supported by Azure.
+
+When using inherited SDK methods, migrate `beta.chat.completions` calls to
+`chat.completions`, and check methods with multiple path parameters for the new
+named-parameter shape. Consult the
+[OpenAI migration guide](https://github.com/openai/openai-node/blob/main/MIGRATION.md)
+for all inherited API changes. The Guardrails wrappers still expose their existing
+`create` methods; this upgrade does not add guarded `parse` or other SDK methods.
+
+OpenAI's `zodResponseFormat` helper supports Zod 4. Structured output schemas must
+follow the API's required-field rules; use nullable fields for optional values.
+This is separate from the JSON-object mode used by built-in LLM checks.
+
+## Agents integration
+
+Upgrade your application's Agents SDK alongside Guardrails and use Zod 4 for
+Agents tools and structured output. See the
+[Agents SDK documentation](https://openai.github.io/openai-agents-js/) for changes
+to directly used Agents APIs.
+
+Guardrails resolves Runner and guardrail types through the public `@openai/agents`
+entry point. Session-backed history no longer depends on npm hoisting the transitive
+`@openai/agents-core` dependency. Input and output guardrails retain conversation
+history when running the built CommonJS package with the matching Agents Runner.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents": "^0.1.3",
-        "openai": "^4.55.0",
-        "zod": "^3.23.8"
+        "@openai/agents": "^0.17.2",
+        "openai": "^7.9.0",
+        "zod": "^4.5.4"
       },
       "bin": {
         "guardrails": "dist/cli.js"
@@ -859,19 +859,6 @@
         }
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.95",
       "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.95.tgz",
@@ -1011,45 +998,36 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.9 || ^2.0.5",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
+        "@modelcontextprotocol/core": "2.0.0",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
         "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "zod": "^4.2.0"
       },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
@@ -1111,132 +1089,70 @@
       }
     },
     "node_modules/@openai/agents": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.1.11.tgz",
-      "integrity": "sha512-jnaFt54iP71vYDXvpG3EGX2kVRYIU2xBdCT3uFqdXm4KqFAP9JQFNGiKKBEeE5rbXARpqAQpKH+5HfoANndpcQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.17.2.tgz",
+      "integrity": "sha512-sNf/XcfJ5VPvvouKTc+ununm+laNEF56x2eNM95SM+ULHzNVLkb7rMOSJXjmn7T3Pc2xdQlEUSvGp2auqzGlcw==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.1.11",
-        "@openai/agents-openai": "0.1.11",
-        "@openai/agents-realtime": "0.1.11",
+        "@openai/agents-core": "0.17.2",
+        "@openai/agents-openai": "0.17.2",
+        "@openai/agents-realtime": "0.17.2",
         "debug": "^4.4.0",
-        "openai": "^5.20.2"
+        "openai": "^7.2.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.40"
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@openai/agents-core": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.1.11.tgz",
-      "integrity": "sha512-ye8VIAO2wPIg1zClldIj8We/1R55VmdgnMyn0g4YGbp6RD5Wpv9yfH5kPNWxmHvw8ji+XehyggGoklY4FGQoBQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.17.2.tgz",
+      "integrity": "sha512-8T5Q5itZSwByPCV6KHpdiKrJ5Ehjhq5pWX+Iq0vLHcY8/TCHt3yAZl9b1dgdcDbfd7UOkPxrBtO3yc87mTnezQ==",
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "debug": "^4.4.0",
-        "openai": "^5.20.2"
+        "openai": "^7.2.0"
       },
       "optionalDependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.2"
+        "@modelcontextprotocol/client": "^2.0.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.40"
+        "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@openai/agents-core/node_modules/openai": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
-      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
         "zod": {
           "optional": true
         }
       }
     },
     "node_modules/@openai/agents-openai": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.1.11.tgz",
-      "integrity": "sha512-TYYbY7o1cNxtOIO4F1a20qkqDT1Iwr9ZEi0MO2sEaeioK8rGB/Ux54iFvsA3IblUYyK+5fD25vr4vXFasvg2Kg==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.17.2.tgz",
+      "integrity": "sha512-zORIq6d0tc6Vyy3CL6sVb9fkeWV8sJmD8+5kv94BaDkSdi2+2kSorgb3n+t0MTuZO4Q19ILe7JvFOcFBokPbjQ==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.1.11",
+        "@openai/agents-core": "0.17.2",
         "debug": "^4.4.0",
-        "openai": "^5.20.2"
+        "openai": "^7.2.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.40"
-      }
-    },
-    "node_modules/@openai/agents-openai/node_modules/openai": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
-      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@openai/agents-realtime": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.1.11.tgz",
-      "integrity": "sha512-8jaNuYU1acra28i7bYrZIPubI6s2ziY2ZudqAVK2ad+giopXcrNSiJTuZ2S3z+ESnIejwMiYLfnY2Le8W0SJ7A==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.17.2.tgz",
+      "integrity": "sha512-ftIkH5pDJNnKOX/t8ormvtcN0PnbpIKzvWJImp4mdOavl6u7GFYQ/XIPu1JDsgHMdJFbQwouHDuo3sTpI9ycNA==",
       "license": "MIT",
       "dependencies": {
-        "@openai/agents-core": "0.1.11",
+        "@openai/agents-core": "0.17.2",
         "@types/ws": "^8.18.1",
         "debug": "^4.4.0",
-        "ws": "^8.18.1"
+        "ws": "^8.21.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.40"
-      }
-    },
-    "node_modules/@openai/agents/node_modules/openai": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
-      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -2009,7 +1925,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/chai": {
@@ -2089,16 +2004,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.9.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/unist": {
@@ -2878,79 +2783,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/algoliasearch": {
       "version": "5.59.0",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.59.0.tgz",
@@ -3036,12 +2868,6 @@
         "js-tokens": "^10.0.0"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3075,45 +2901,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/body-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
-      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^2.0.0",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.1",
-        "iconv-lite": "^0.7.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.15.2",
-        "raw-body": "^3.0.2",
-        "type-is": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
@@ -3138,46 +2925,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ccount": {
@@ -3230,18 +2977,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3253,56 +2988,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6.6.0"
-      }
     },
     "node_modules/copy-anything": {
       "version": "4.1.0",
@@ -3315,24 +3006,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -3372,25 +3045,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -3450,43 +3104,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/emoji-regex-xs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
       "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -3515,64 +3138,12 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
       "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -3596,25 +3167,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/eventsource": {
@@ -3650,83 +3202,12 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
-      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.4.3",
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
     "node_modules/extendable-error": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
       "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3758,23 +3239,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fast-uri": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
-      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
     "node_modules/fastq": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
@@ -3796,28 +3260,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3842,82 +3284,6 @@
       "license": "MIT",
       "dependencies": {
         "tabbable": "^6.4.0"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -3948,52 +3314,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -4045,18 +3365,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4072,45 +3380,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-to-html": {
@@ -4151,16 +3420,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hono": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
-      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -4186,27 +3445,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/human-id": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.1.tgz",
@@ -4217,20 +3455,11 @@
         "human-id": "dist/cli.js"
       }
     },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4241,33 +3470,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/ip-address": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
-      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/is-extglob": {
@@ -4302,13 +3504,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/is-subdir": {
       "version": "1.2.0",
@@ -4418,20 +3613,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause",
-      "optional": true
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -4791,15 +3972,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
@@ -4820,33 +3992,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
-      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -4967,33 +4112,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -5069,100 +4187,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/negotiator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
-      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "content-type": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/negotiator/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/obug": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
@@ -5175,29 +4199,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/oniguruma-to-es": {
@@ -5213,27 +4214,34 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.9.0.tgz",
+      "integrity": "sha512-Qfx4qKmPllnilbuP6NgEj5KPUxLShYxrlRPWh3ZRQgNgs5B1V52PrfAdEQbW9MTGq7MquDYFMm+K/KXxiY736w==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
+      "engines": {
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "undici": ">=5 <9",
+        "ws": "^8.21.0",
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "undici": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },
@@ -5241,21 +4249,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/outdent": {
       "version": "0.5.0",
@@ -5343,16 +4336,6 @@
         "quansync": "^0.2.7"
       }
     },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5388,17 +4371,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -5524,37 +4496,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
-      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -5592,36 +4533,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/range-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
-      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",
@@ -5689,16 +4600,6 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -5828,23 +4729,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5873,7 +4757,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/search-insights": {
@@ -5896,60 +4780,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5989,82 +4819,6 @@
         "@shikijs/types": "2.5.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -6152,16 +4906,6 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/std-env": {
       "version": "4.2.0",
@@ -6342,22 +5086,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -6367,39 +5095,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/type-is/node_modules/content-type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
-      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -6524,26 +5219,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -7438,31 +6113,6 @@
         }
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7496,13 +6146,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/ws": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
@@ -7525,22 +6168,12 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "optional": true,
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   },
   "homepage": "https://openai.github.io/openai-guardrails-js/",
   "dependencies": {
-    "@openai/agents": "^0.1.3",
-    "openai": "^4.55.0",
-    "zod": "^3.23.8"
+    "@openai/agents": "^0.17.2",
+    "openai": "^7.9.0",
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.11",

--- a/src/__tests__/integration/fixtures/sdk-types.ts
+++ b/src/__tests__/integration/fixtures/sdk-types.ts
@@ -1,0 +1,70 @@
+import { Agent, tool } from '@openai/agents';
+import { OpenAI } from 'openai';
+import { zodResponseFormat } from 'openai/helpers/zod';
+import { z } from 'zod';
+import { z as z3 } from 'zod/v3';
+import {
+  GuardrailRegistry,
+  GuardrailsAzureOpenAI,
+  GuardrailsOpenAI,
+  LLMConfig,
+  LLMOutput,
+  runLLM,
+} from '../../../..';
+
+const registry = new GuardrailRegistry();
+const configSchema = z.object({ limit: z.number().default(3) });
+registry.register(
+  'custom',
+  (_context, text: string, config: z.output<typeof configSchema>) => ({
+    tripwireTriggered: text.length > config.limit,
+    info: {},
+  }),
+  'Custom Zod 4 config',
+  'text/plain',
+  configSchema
+);
+// @ts-expect-error Zod 3 configuration schemas are no longer compatible.
+const oldSchema: z.ZodType = z3.object({});
+void oldSchema;
+
+const modelConfig: z.input<typeof LLMConfig> = { model: 'test-model' };
+const parsedConfig: z.output<typeof LLMConfig> = LLMConfig.parse(modelConfig);
+const confidence: number = parsedConfig.confidence_threshold;
+const output = LLMOutput.extend({ labels: z.array(z.string()) });
+const openai = new OpenAI({ apiKey: 'test-key' });
+void runLLM('text', 'Check', openai, 'test-model', output).then(([result]) => {
+  const flagged: boolean = result.flagged;
+  return flagged;
+});
+void confidence;
+
+const agentTool = tool({
+  name: 'echo',
+  description: 'Echo text',
+  parameters: z.object({ text: z.string() }),
+  execute: async ({ text }) => text,
+});
+new Agent({ name: 'typed', tools: [agentTool], outputType: z.object({ answer: z.string() }) });
+
+async function clients() {
+  const client = await GuardrailsOpenAI.create({ version: 1 }, { apiKey: 'test-key' });
+  await client.guardrails.chat.completions.create(
+    {
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'Hello' }],
+      response_format: zodResponseFormat(output, 'output'),
+    },
+    { maxRetries: 0, headers: { 'x-test': 'yes' } }
+  );
+  const azure = await GuardrailsAzureOpenAI.create(
+    { version: 1 },
+    {
+      apiKey: 'test-key',
+      endpoint: 'https://example.openai.azure.com',
+      apiVersion: 'test',
+    }
+  );
+  await azure.guardrails.responses.create({ model: 'test-model', input: 'Hello' });
+}
+void clients;

--- a/src/__tests__/integration/sdk-compat.test.ts
+++ b/src/__tests__/integration/sdk-compat.test.ts
@@ -1,5 +1,7 @@
 import { createRequire } from 'node:module';
+import type { OpenAI } from 'openai';
 import { describe, expect, it, vi } from 'vitest';
+import type { GuardrailLLMContext } from '../../types';
 
 // Exercise the published CommonJS entry and its actual dependency identities.
 // Run `npm run build` first, as CI does; source-only mocks miss Runner patches.
@@ -13,6 +15,79 @@ const { z } = require('zod') as typeof import('zod');
 const { zodResponseFormat } = require('openai/helpers/zod') as typeof import('openai/helpers/zod');
 
 describe('published SDK compatibility', () => {
+  it('preserves lazy rotating API-key callbacks for the separate guardrail client', async () => {
+    vi.stubEnv('OPENAI_API_KEY', undefined);
+    vi.stubEnv('OPENAI_ADMIN_KEY', undefined);
+    const apiKey = vi
+      .fn()
+      .mockResolvedValueOnce('test-main')
+      .mockResolvedValueOnce('test-guardrail-1')
+      .mockResolvedValueOnce('test-guardrail-2');
+    const fetch = vi.fn().mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: 'chatcmpl-test',
+            object: 'chat.completion',
+            created: 1,
+            model: 'test-model',
+            choices: [
+              { index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } },
+            ],
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        )
+    );
+    let guardrailClient: OpenAI | undefined;
+    const name = 'Capture credential client';
+    defaultSpecRegistry.register(
+      name,
+      (ctx: GuardrailLLMContext) => {
+        guardrailClient = ctx.guardrailLlm;
+        return { tripwireTriggered: false, info: {} };
+      },
+      'Capture credential client'
+    );
+    try {
+      const client = await GuardrailsOpenAI.create(
+        {
+          version: 1,
+          pre_flight: { version: 1, guardrails: [{ name, config: {} }] },
+        },
+        { apiKey, fetch, maxRetries: 0 }
+      );
+      expect(apiKey).not.toHaveBeenCalled();
+      const params = {
+        model: 'test-model',
+        messages: [{ role: 'user' as const, content: 'Hello' }],
+      };
+      await client.chat.completions.create(params);
+      expect(guardrailClient).toBeDefined();
+      if (!guardrailClient) throw new Error('Guardrail context was not captured');
+      expect(guardrailClient).not.toBe(client);
+      expect(guardrailClient.apiKey).toBeNull();
+      const guardrailFetch = vi.spyOn(guardrailClient, 'fetch').mockImplementation(fetch);
+      try {
+        await guardrailClient.chat.completions.create(params);
+        await guardrailClient.chat.completions.create(params);
+        expect(apiKey).toHaveBeenCalledTimes(3);
+        expect(
+          fetch.mock.calls.map(([, init]) => new Headers(init.headers).get('authorization'))
+        ).toEqual(['Bearer test-main', 'Bearer test-guardrail-1', 'Bearer test-guardrail-2']);
+        apiKey.mockRejectedValueOnce(new Error('credential unavailable'));
+        await expect(guardrailClient.chat.completions.create(params)).rejects.toThrow(
+          'credential unavailable'
+        );
+        expect(fetch).toHaveBeenCalledTimes(3);
+      } finally {
+        guardrailFetch.mockRestore();
+      }
+    } finally {
+      defaultSpecRegistry.remove(name);
+      vi.unstubAllEnvs();
+    }
+  });
+
   it('runs real Agents input and output guardrails with session history', async () => {
     vi.stubEnv('OPENAI_API_KEY', 'test-key');
     const seen: Array<{ text: string; history: unknown }> = [];

--- a/src/__tests__/integration/sdk-compat.test.ts
+++ b/src/__tests__/integration/sdk-compat.test.ts
@@ -66,22 +66,18 @@ describe('published SDK compatibility', () => {
       if (!guardrailClient) throw new Error('Guardrail context was not captured');
       expect(guardrailClient).not.toBe(client);
       expect(guardrailClient.apiKey).toBeNull();
-      const guardrailFetch = vi.spyOn(guardrailClient, 'fetch').mockImplementation(fetch);
-      try {
-        await guardrailClient.chat.completions.create(params);
-        await guardrailClient.chat.completions.create(params);
-        expect(apiKey).toHaveBeenCalledTimes(3);
-        expect(
-          fetch.mock.calls.map(([, init]) => new Headers(init.headers).get('authorization'))
-        ).toEqual(['Bearer test-main', 'Bearer test-guardrail-1', 'Bearer test-guardrail-2']);
-        apiKey.mockRejectedValueOnce(new Error('credential unavailable'));
-        await expect(guardrailClient.chat.completions.create(params)).rejects.toThrow(
-          'credential unavailable'
-        );
-        expect(fetch).toHaveBeenCalledTimes(3);
-      } finally {
-        guardrailFetch.mockRestore();
-      }
+      expect(guardrailClient.fetch).toBe(fetch);
+      await guardrailClient.chat.completions.create(params);
+      await guardrailClient.chat.completions.create(params);
+      expect(apiKey).toHaveBeenCalledTimes(3);
+      expect(
+        fetch.mock.calls.map(([, init]) => new Headers(init.headers).get('authorization'))
+      ).toEqual(['Bearer test-main', 'Bearer test-guardrail-1', 'Bearer test-guardrail-2']);
+      apiKey.mockRejectedValueOnce(new Error('credential unavailable'));
+      await expect(guardrailClient.chat.completions.create(params)).rejects.toThrow(
+        'credential unavailable'
+      );
+      expect(fetch).toHaveBeenCalledTimes(3);
     } finally {
       defaultSpecRegistry.remove(name);
       vi.unstubAllEnvs();

--- a/src/__tests__/integration/sdk-compat.test.ts
+++ b/src/__tests__/integration/sdk-compat.test.ts
@@ -14,6 +14,7 @@ const { zodResponseFormat } = require('openai/helpers/zod') as typeof import('op
 
 describe('published SDK compatibility', () => {
   it('runs real Agents input and output guardrails with session history', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'test-key');
     const seen: Array<{ text: string; history: unknown }> = [];
     const name = 'SDK migration history';
     defaultSpecRegistry.register(
@@ -71,6 +72,7 @@ describe('published SDK compatibility', () => {
       model.assertComplete();
     } finally {
       defaultSpecRegistry.remove(name);
+      vi.unstubAllEnvs();
     }
   });
 

--- a/src/__tests__/integration/sdk-compat.test.ts
+++ b/src/__tests__/integration/sdk-compat.test.ts
@@ -1,0 +1,125 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it, vi } from 'vitest';
+
+// Exercise the published CommonJS entry and its actual dependency identities.
+// Run `npm run build` first, as CI does; source-only mocks miss Runner patches.
+const require = createRequire(import.meta.url);
+const { GuardrailAgent, defaultSpecRegistry, GuardrailsOpenAI, GuardrailsAzureOpenAI } =
+  require('../../..') as typeof import('../../index');
+const { MemorySession, Runner } = require('@openai/agents') as typeof import('@openai/agents');
+const { ScriptedModel, assistantMessage } =
+  require('@openai/agents/testing') as typeof import('@openai/agents/testing');
+const { z } = require('zod') as typeof import('zod');
+const { zodResponseFormat } = require('openai/helpers/zod') as typeof import('openai/helpers/zod');
+
+describe('published SDK compatibility', () => {
+  it('runs real Agents input and output guardrails with session history', async () => {
+    const seen: Array<{ text: string; history: unknown }> = [];
+    const name = 'SDK migration history';
+    defaultSpecRegistry.register(
+      name,
+      (ctx: { getConversationHistory?: () => unknown }, text: string) => {
+        seen.push({ text, history: ctx.getConversationHistory?.() });
+        return { tripwireTriggered: false, info: {} };
+      },
+      'Capture history',
+      'text/plain',
+      z.object({}),
+      z.object({}).passthrough(),
+      { usesConversationHistory: true }
+    );
+    try {
+      const model = new ScriptedModel([[assistantMessage('Current answer')]]);
+      const agent = await GuardrailAgent.create(
+        {
+          version: 1,
+          input: { version: 1, guardrails: [{ name, config: {} }] },
+          output: { version: 1, guardrails: [{ name, config: {} }] },
+        },
+        'Session test',
+        undefined,
+        { model },
+        true
+      );
+      const session = new MemorySession({
+        initialItems: [
+          { role: 'user', content: 'Earlier question' },
+          assistantMessage('Earlier answer'),
+        ],
+      });
+      const result = await new Runner({ tracingDisabled: true }).run(
+        agent as Parameters<InstanceType<typeof Runner>['run']>[0],
+        'Current question',
+        { session, context: { guardrailLlm: {} } }
+      );
+      expect(result.finalOutput).toBe('Current answer');
+      expect(seen.map((entry) => entry.text)).toEqual(['Current question', 'Current answer']);
+      for (const entry of seen) {
+        expect(entry.history).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ role: 'user', content: 'Earlier question' }),
+            expect.objectContaining({ role: 'assistant', content: 'Earlier answer' }),
+            expect.objectContaining({ role: 'user', content: 'Current question' }),
+          ])
+        );
+      }
+      expect(seen[1].history).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ role: 'assistant', content: 'Current answer' }),
+        ])
+      );
+      model.assertComplete();
+    } finally {
+      defaultSpecRegistry.remove(name);
+    }
+  });
+
+  it.each(['openai', 'azure'] as const)(
+    'uses %s with native fetch, request options, and Zod 4 structured output',
+    async (provider) => {
+      const fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 'chatcmpl-test',
+            object: 'chat.completion',
+            created: 1,
+            model: 'test-model',
+            choices: [
+              {
+                index: 0,
+                finish_reason: 'stop',
+                message: { role: 'assistant', content: '{"answer":"ok"}' },
+              },
+            ],
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      );
+      const config = { version: 1 };
+      const client =
+        provider === 'azure'
+          ? await GuardrailsAzureOpenAI.create(config, {
+              apiKey: 'test-key',
+              endpoint: 'https://example.openai.azure.com',
+              apiVersion: '2025-01-01-preview',
+              fetch,
+            })
+          : await GuardrailsOpenAI.create(config, { apiKey: 'test-key', fetch });
+      const response = await client.chat.completions.create(
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'Hello' }],
+          response_format: zodResponseFormat(z.object({ answer: z.string() }), 'answer'),
+        },
+        { headers: { 'x-migration-test': 'yes' }, maxRetries: 0 }
+      );
+      expect(response.choices[0].message.content).toBe('{"answer":"ok"}');
+      const [url, init] = fetch.mock.calls[0];
+      expect(new Headers(init.headers).get('x-migration-test')).toBe('yes');
+      expect(String(url)).toContain(
+        provider === 'azure' ? 'example.openai.azure.com' : 'api.openai.com'
+      );
+      expect(JSON.parse(init.body).response_format.json_schema.schema.required).toEqual(['answer']);
+    }
+  );
+});

--- a/src/__tests__/integration/sdk-migration-feedback.test.ts
+++ b/src/__tests__/integration/sdk-migration-feedback.test.ts
@@ -1,0 +1,233 @@
+import { createRequire } from 'node:module';
+import { setImmediate } from 'node:timers/promises';
+import type { OpenAI } from 'openai';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { GuardrailLLMContext } from '../../types';
+
+const require = createRequire(import.meta.url);
+const { GuardrailAgent, defaultSpecRegistry, GuardrailsOpenAI, GuardrailsAzureOpenAI } =
+  require('../../..') as typeof import('../../index');
+const { Runner } = require('@openai/agents') as typeof import('@openai/agents');
+const { ScriptedModel, assistantMessage } =
+  require('@openai/agents/testing') as typeof import('@openai/agents/testing');
+const { bedrock } =
+  require('openai/providers/bedrock') as typeof import('openai/providers/bedrock');
+const params = { model: 'test-model', messages: [{ role: 'user' as const, content: 'Hello' }] };
+
+function completion() {
+  return new Response(
+    JSON.stringify({
+      id: 'test',
+      object: 'chat.completion',
+      created: 1,
+      model: 'test-model',
+      choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } }],
+    }),
+    { headers: { 'content-type': 'application/json' } }
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('SDK migration feedback', () => {
+  it.each([false, true])(
+    'blocks model dispatch until preflight completes, tripwire=%s',
+    async (tripwireTriggered) => {
+      vi.stubEnv('OPENAI_API_KEY', 'test-key');
+      const name = 'Blocking migration preflight';
+      let release: () => void = () => undefined;
+      let markStarted: () => void = () => undefined;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const check = vi.fn(async () => {
+        markStarted();
+        await gate;
+        return { tripwireTriggered, info: {} };
+      });
+      defaultSpecRegistry.register(name, check, 'Blocking migration preflight');
+      try {
+        const model = new ScriptedModel([[assistantMessage('completed')]]);
+        const dispatch = vi.spyOn(model, 'getResponse');
+        const agent = await GuardrailAgent.create(
+          {
+            version: 1,
+            pre_flight: { version: 1, guardrails: [{ name, config: {} }] },
+            input: { version: 1, guardrails: [{ name, config: {} }] },
+          },
+          'Blocking test',
+          undefined,
+          { model }
+        );
+        const result = new Runner({ tracingDisabled: true }).run(
+          agent as Parameters<InstanceType<typeof Runner>['run']>[0],
+          'Hello',
+          { context: { guardrailLlm: {} } }
+        );
+        const settled = tripwireTriggered
+          ? expect(result).rejects.toThrow()
+          : expect(result).resolves.toMatchObject({ finalOutput: 'completed' });
+        await started;
+        await setImmediate();
+        expect(check).toHaveBeenCalled();
+        expect(dispatch).not.toHaveBeenCalled();
+        release();
+        await settled;
+        expect(dispatch).toHaveBeenCalledTimes(tripwireTriggered ? 0 : 1);
+        expect(
+          (
+            agent as { inputGuardrails: Array<{ name: string; runInParallel?: boolean }> }
+          ).inputGuardrails.find((guard) => guard.name.startsWith('input:'))?.runInParallel
+        ).not.toBe(false);
+      } finally {
+        release();
+        defaultSpecRegistry.remove(name);
+      }
+    }
+  );
+
+  it.each(['bedrock', 'workload'] as const)(
+    'preserves %s authentication in guardrail context',
+    async (mode) => {
+      vi.stubEnv('OPENAI_API_KEY', undefined);
+      vi.stubEnv('OPENAI_ADMIN_KEY', undefined);
+      const token = vi.fn().mockResolvedValue('external-token');
+      const fetch = vi.fn(async (url: RequestInfo | URL) => {
+        if (String(url).includes('/oauth/token')) {
+          return new Response(
+            JSON.stringify({
+              access_token: 'exchanged-token',
+              token_type: 'Bearer',
+              issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+              expires_in: 3600,
+            }),
+            { headers: { 'content-type': 'application/json' } }
+          );
+        }
+        return completion();
+      });
+      const name = `Migration ${mode} auth`;
+      let contextClient: OpenAI | undefined;
+      defaultSpecRegistry.register(
+        name,
+        async (ctx: GuardrailLLMContext) => {
+          contextClient = ctx.guardrailLlm;
+          await ctx.guardrailLlm.chat.completions.create(params);
+          return { tripwireTriggered: false, info: {} };
+        },
+        name
+      );
+      try {
+        const auth =
+          mode === 'bedrock'
+            ? { provider: bedrock({ region: 'us-east-1', tokenProvider: token }) }
+            : {
+                workloadIdentity: {
+                  identityProviderId: 'idp_test',
+                  serviceAccountId: 'sa_test',
+                  provider: { tokenType: 'jwt' as const, getToken: token },
+                },
+              };
+        const client = await GuardrailsOpenAI.create(
+          { version: 1, pre_flight: { version: 1, guardrails: [{ name, config: {} }] } },
+          { ...auth, fetch, maxRetries: 0 },
+          true
+        );
+        expect(token).not.toHaveBeenCalled();
+        await client.withOptions({ timeout: 1234 }).chat.completions.create(params);
+        expect(contextClient).not.toBe(client);
+        const calls = fetch.mock.calls.filter(([url]) => !String(url).includes('/oauth/token'));
+        expect(calls).toHaveLength(2);
+        for (const call of calls) {
+          const init = (call as unknown as [unknown, RequestInit])[1];
+          expect(new Headers(init.headers).get('authorization')).toBe(
+            mode === 'bedrock' ? 'Bearer external-token' : 'Bearer exchanged-token'
+          );
+          expect(String(call[0])).toContain(
+            mode === 'bedrock' ? 'bedrock-mantle' : 'api.openai.com'
+          );
+        }
+      } finally {
+        defaultSpecRegistry.remove(name);
+      }
+    }
+  );
+
+  it.each(['openai', 'azure'] as const)(
+    'preserves initialized guards and options when cloning %s',
+    async (mode) => {
+      vi.stubEnv('OPENAI_API_KEY', undefined);
+      vi.stubEnv('OPENAI_ADMIN_KEY', undefined);
+      vi.stubEnv('AZURE_OPENAI_API_KEY', undefined);
+      vi.stubEnv('OPENAI_API_VERSION', undefined);
+      const originalFetch = vi.fn(async () => completion());
+      const cloneFetch = vi.fn(async () => completion());
+      const check = vi.fn(() => ({ tripwireTriggered: false, info: {} }));
+      const name = `Migration clone ${mode}`;
+      defaultSpecRegistry.register(name, check, name);
+      try {
+        const config = {
+          version: 1,
+          pre_flight: { version: 1, guardrails: [{ name, config: {} }] },
+        };
+        const original =
+          mode === 'azure'
+            ? await GuardrailsAzureOpenAI.create(
+                config,
+                {
+                  apiKey: 'original',
+                  endpoint: 'https://example.openai.azure.com',
+                  apiVersion: '2025-01-01-preview',
+                  deployment: 'test-deployment',
+                  fetch: originalFetch,
+                },
+                true
+              )
+            : await GuardrailsOpenAI.create(
+                config,
+                { apiKey: 'original', fetch: originalFetch },
+                true
+              );
+        const cloned = original
+          .withOptions({
+            apiKey: 'cloned',
+            fetch: cloneFetch,
+            timeout: 1234,
+            maxRetries: 0,
+            defaultHeaders: { 'x-cloned': 'yes' },
+          })
+          .withOptions({});
+        expect(cloned).toBeInstanceOf(original.constructor);
+        expect(cloned).not.toBe(original);
+        expect(cloned.timeout).toBe(1234);
+        await cloned.guardrails.chat.completions.create(params);
+        await original.guardrails.chat.completions.create(params);
+        expect(check).toHaveBeenCalledTimes(2);
+        expect(cloneFetch).toHaveBeenCalledOnce();
+        expect(originalFetch).toHaveBeenCalledOnce();
+        const [url, init] = cloneFetch.mock.calls[0] as unknown as [string, RequestInit];
+        expect(new Headers(init.headers).get('x-cloned')).toBe('yes');
+        expect(new Headers(init.headers).get(mode === 'azure' ? 'api-key' : 'authorization')).toBe(
+          mode === 'azure' ? 'cloned' : 'Bearer cloned'
+        );
+        if (mode === 'azure') {
+          expect(String(url)).toContain('/deployments/test-deployment/');
+          expect(String(url)).toContain('api-version=2025-01-01-preview');
+        }
+        check.mockImplementation(() => {
+          throw new Error('guardrail failed');
+        });
+        await expect(cloned.chat.completions.create(params)).rejects.toThrow('guardrail failed');
+        expect(cloneFetch).toHaveBeenCalledOnce();
+      } finally {
+        defaultSpecRegistry.remove(name);
+      }
+    }
+  );
+});

--- a/src/__tests__/integration/sdk-types.test.ts
+++ b/src/__tests__/integration/sdk-types.test.ts
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
-import ts from 'typescript';
 import { expect, it } from 'vitest';
+
+// Load the compiler's CommonJS API without Vite's default-export interop.
+const ts = createRequire(import.meta.url)('typescript') as typeof import('typescript');
 
 it('accepts migrated public schemas and client types in a consumer', () => {
   const program = ts.createProgram(

--- a/src/__tests__/integration/sdk-types.test.ts
+++ b/src/__tests__/integration/sdk-types.test.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { expect, it } from 'vitest';
+
+it('accepts migrated public schemas and client types in a consumer', () => {
+  const program = ts.createProgram(
+    [fileURLToPath(new URL('./fixtures/sdk-types.ts', import.meta.url))],
+    {
+      noEmit: true,
+      strict: true,
+      exactOptionalPropertyTypes: true,
+      skipLibCheck: true,
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.Node16,
+      moduleResolution: ts.ModuleResolutionKind.Node16,
+      esModuleInterop: true,
+    }
+  );
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  expect(
+    diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+  ).toEqual([]);
+}, 15_000);

--- a/src/__tests__/integration/sdk-types.test.ts
+++ b/src/__tests__/integration/sdk-types.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { it } from 'vitest';
 
@@ -10,7 +11,10 @@ it('accepts migrated public schemas and client types in a consumer', () => {
   execFileSync(
     process.execPath,
     [
-      require.resolve('typescript/bin/tsc'),
+      resolve(
+        dirname(require.resolve('typescript/package.json')),
+        require('typescript/package.json').bin.tsc
+      ),
       '--ignoreConfig',
       '--noEmit',
       '--strict',

--- a/src/__tests__/integration/sdk-types.test.ts
+++ b/src/__tests__/integration/sdk-types.test.ts
@@ -1,26 +1,30 @@
+import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
-import { expect, it } from 'vitest';
+import { it } from 'vitest';
 
-// Load the compiler's CommonJS API without Vite's default-export interop.
-const ts = createRequire(import.meta.url)('typescript') as typeof import('typescript');
+const require = createRequire(import.meta.url);
 
 it('accepts migrated public schemas and client types in a consumer', () => {
-  const program = ts.createProgram(
-    [fileURLToPath(new URL('./fixtures/sdk-types.ts', import.meta.url))],
-    {
-      noEmit: true,
-      strict: true,
-      exactOptionalPropertyTypes: true,
-      skipLibCheck: true,
-      target: ts.ScriptTarget.ES2020,
-      module: ts.ModuleKind.Node16,
-      moduleResolution: ts.ModuleResolutionKind.Node16,
-      esModuleInterop: true,
-    }
+  // Use the same compiler CLI as the package build, outside the test runner.
+  execFileSync(
+    process.execPath,
+    [
+      require.resolve('typescript/bin/tsc'),
+      '--ignoreConfig',
+      '--noEmit',
+      '--strict',
+      '--exactOptionalPropertyTypes',
+      '--skipLibCheck',
+      '--target',
+      'ES2020',
+      '--module',
+      'Node16',
+      '--moduleResolution',
+      'Node16',
+      '--esModuleInterop',
+      fileURLToPath(new URL('./fixtures/sdk-types.ts', import.meta.url)),
+    ],
+    { encoding: 'utf8' }
   );
-  const diagnostics = ts.getPreEmitDiagnostics(program);
-  expect(
-    diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
-  ).toEqual([]);
 }, 15_000);

--- a/src/__tests__/unit/agents.test.ts
+++ b/src/__tests__/unit/agents.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for GuardrailAgent functionality.
  */
 
-import type { InputGuardrail, OutputGuardrail } from '@openai/agents-core';
+import type { InputGuardrail, OutputGuardrail } from '@openai/agents';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { GuardrailAgent } from '../../agents';

--- a/src/__tests__/unit/checks/pii.test.ts
+++ b/src/__tests__/unit/checks/pii.test.ts
@@ -6,6 +6,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { _clearDeprecationWarnings, PIIConfig, PIIEntity, pii } from '../../../checks/pii';
 
 describe('pii guardrail', () => {
+  it('keeps defaults independent when a parsed config or result metadata is mutated', async () => {
+    const first = PIIConfig.parse({});
+    const second = PIIConfig.parse({});
+    const defaults = [...second.entities];
+    expect(first.entities).not.toBe(second.entities);
+
+    first.entities.splice(0);
+    expect(second.entities).toEqual(defaults);
+    const result = await pii({}, 'Contact john@example.com', second);
+    const checked = result.info.entity_types_checked as PIIEntity[];
+    checked.splice(0);
+    expect(PIIConfig.parse({}).entities).toEqual(defaults);
+  });
+
   it('masks detected PII when block=false', async () => {
     const config = PIIConfig.parse({
       entities: [PIIEntity.EMAIL_ADDRESS, PIIEntity.US_SSN],

--- a/src/__tests__/unit/client.test.ts
+++ b/src/__tests__/unit/client.test.ts
@@ -51,6 +51,10 @@ class MockOpenAI {
     openAiInstances.push(this);
   }
 
+  public withOptions = vi.fn(
+    (options: MockOpenAIOptions) => new MockOpenAI({ ...this.options, ...options })
+  );
+
   public apiKey?: string;
   public baseURL?: string;
   public organization?: string;

--- a/src/__tests__/unit/llm-base.test.ts
+++ b/src/__tests__/unit/llm-base.test.ts
@@ -1,5 +1,6 @@
 import type { OpenAI } from 'openai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import {
   buildAnalysisPayload,
   buildFullPrompt,
@@ -112,6 +113,28 @@ describe('LLM Base', () => {
   });
 
   describe('buildFullPrompt', () => {
+    it('describes Zod 4 fields without treating arrays or type discriminators as wrappers', () => {
+      const prompt = buildFullPrompt(
+        'Check the text',
+        z.object({
+          detected: z.boolean().optional(),
+          score: z.number().default(0),
+          explanation: z.string().nullable().readonly(),
+          labels: z.array(z.string()).optional(),
+          details: z.object({ label: z.string() }),
+          transformed: z.string().transform((text) => text.length),
+          preprocessed: z.preprocess((value) => value, z.number()),
+        })
+      );
+      expect(prompt).toContain('- "detected": boolean');
+      expect(prompt).toContain('- "score": float');
+      expect(prompt).toContain('- "explanation": string');
+      expect(prompt).toContain('- "labels": array');
+      expect(prompt).toContain('- "details": object');
+      expect(prompt).toContain('- "transformed": string');
+      expect(prompt).toContain('- "preprocessed": float');
+    });
+
     it.each([
       'Respond with a JSON object',
       'output json',

--- a/src/__tests__/unit/spec.test.ts
+++ b/src/__tests__/unit/spec.test.ts
@@ -216,7 +216,7 @@ describe('Spec Module', () => {
       const complexContext = z.object({
         user: z.string(),
         permissions: z.array(z.string()),
-        settings: z.record(z.unknown()),
+        settings: z.record(z.string(), z.unknown()),
       });
 
       const spec = new GuardrailSpec(

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -618,6 +618,7 @@ async function createInputGuardrailsFromStage(
 
   return guardrails.map((guardrail: ConfiguredGuardrail) => ({
     name: `${stageName}: ${guardrail.definition.name || 'Unknown Guardrail'}`,
+    ...(stageName === 'pre_flight' ? { runInParallel: false } : {}),
     execute: async (args: InputGuardrailFunctionArgs) => {
       const { input, context: agentContext } = args;
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -12,7 +12,7 @@ import type {
   InputGuardrailFunctionArgs,
   OutputGuardrail,
   OutputGuardrailFunctionArgs,
-} from '@openai/agents-core';
+} from '@openai/agents';
 import {
   type ConfiguredGuardrail,
   type GuardrailBundle,
@@ -468,7 +468,7 @@ function ensureAgentRunnerPatch(): void {
   }
 
   try {
-    const agentsCore = require('@openai/agents-core');
+    const agentsCore = require('@openai/agents');
     const { Runner } = agentsCore ?? {};
 
     if (!Runner || typeof Runner.prototype?.run !== 'function') {

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -365,7 +365,13 @@ export abstract class GuardrailsBaseClient {
     openaiArgs: ConstructorParameters<typeof OpenAI>[0],
     clientClass: typeof OpenAI | typeof AzureOpenAI
   ): Promise<void> {
-    this._resourceClient = new clientClass(openaiArgs);
+    // The caller pairs options with its concrete client class. OpenAI 7 excludes
+    // provider routing options from Azure, so a union of constructors no longer
+    // accepts the broader OpenAI options type. Preserve the options unchanged;
+    // the selected SDK constructor performs its own provider validation.
+    this._resourceClient = new clientClass(
+      openaiArgs as ConstructorParameters<typeof AzureOpenAI>[0]
+    );
     await this.setupGuardrails(config);
     this.overrideResources();
   }

--- a/src/checks/llm-base.ts
+++ b/src/checks/llm-base.ts
@@ -155,32 +155,32 @@ export function createErrorResult(
  * @returns Formatted prompt string for LLM input.
  */
 function unwrapSchema(schema: ZodTypeAny): ZodTypeAny {
-  if ('unwrap' in schema && typeof schema.unwrap === 'function') {
-    return unwrapSchema(schema.unwrap());
+  // Unwrap value wrappers only: arrays also expose unwrap(), but remain arrays.
+  if (
+    schema instanceof z.ZodOptional ||
+    schema instanceof z.ZodNullable ||
+    schema instanceof z.ZodDefault ||
+    schema instanceof z.ZodPrefault ||
+    schema instanceof z.ZodCatch ||
+    schema instanceof z.ZodReadonly ||
+    schema instanceof z.ZodNonOptional
+  ) {
+    const inner = schema.unwrap();
+    return inner instanceof z.ZodType ? unwrapSchema(inner) : schema;
   }
 
-  const def = (schema as { _def?: Record<string, unknown> })._def as
-    | {
-        innerType?: ZodTypeAny;
-        schema?: ZodTypeAny;
-        type?: ZodTypeAny;
-      }
-    | undefined;
-
-  if (!def) {
-    return schema;
-  }
-
-  if (def.innerType) {
-    return unwrapSchema(def.innerType);
-  }
-
-  if (def.schema) {
-    return unwrapSchema(def.schema as ZodTypeAny);
-  }
-
-  if (def.type) {
-    return unwrapSchema(def.type as ZodTypeAny);
+  // Zod 4 represents transforms/preprocessors as pipes. Describe the JSON
+  // input before a transform, or the target schema after a preprocessor.
+  if (schema instanceof z.ZodPipe) {
+    const inner =
+      schema.out instanceof z.ZodTransform
+        ? schema.in
+        : schema.in instanceof z.ZodTransform
+          ? schema.out
+          : undefined;
+    if (inner instanceof z.ZodType) {
+      return unwrapSchema(inner);
+    }
   }
 
   return schema;

--- a/src/checks/pii.ts
+++ b/src/checks/pii.ts
@@ -164,7 +164,7 @@ const DEFAULT_PII_ENTITIES: PIIEntity[] = Object.values(PIIEntity).filter(
 );
 
 export const PIIConfig = z.object({
-  entities: z.array(z.nativeEnum(PIIEntity)).default(() => DEFAULT_PII_ENTITIES),
+  entities: z.array(z.nativeEnum(PIIEntity)).default(() => [...DEFAULT_PII_ENTITIES]),
   block: z
     .boolean()
     .default(false)

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@
  * applying guardrails to text-based methods that could benefit from validation.
  */
 
-import { AzureOpenAI, type ClientOptions, OpenAI } from 'openai';
+import { type AzureClientOptions, AzureOpenAI, type ClientOptions, OpenAI } from 'openai';
 import { GuardrailsBaseClient, type PipelineConfig } from './base-client';
 import type { Chat as GuardrailsChat } from './resources/chat';
 import type { Responses as GuardrailsResponses } from './resources/responses';
@@ -28,7 +28,7 @@ export { GuardrailResults, GuardrailsResponse } from './base-client';
  * All other methods pass through unchanged for full API compatibility.
  */
 export class GuardrailsOpenAI extends OpenAI {
-  private guardrailsClient: GuardrailsBaseClientImpl;
+  private guardrailsClient!: GuardrailsBaseClientImpl;
 
   // Retain OpenAI's original types for drop-in compatibility
   public override chat!: InstanceType<typeof OpenAI>['chat'];
@@ -41,17 +41,17 @@ export class GuardrailsOpenAI extends OpenAI {
   public override responses!: InstanceType<typeof OpenAI>['responses'];
 
   private constructor(
-    guardrailsClient: GuardrailsBaseClientImpl,
-    options?: ConstructorParameters<typeof OpenAI>[0]
+    options?: ConstructorParameters<typeof OpenAI>[0],
+    guardrailsClient?: GuardrailsBaseClientImpl
   ) {
     // Initialize OpenAI client first
     super(options);
 
-    // Store the initialized guardrails client
-    this.guardrailsClient = guardrailsClient;
-
-    // Override chat and responses after initialization
-    this.overrideResources();
+    // SDK withOptions constructs the clone before its initialized guards are attached.
+    if (guardrailsClient) {
+      this.guardrailsClient = guardrailsClient;
+      this.overrideResources();
+    }
   }
 
   /**
@@ -71,14 +71,22 @@ export class GuardrailsOpenAI extends OpenAI {
     raiseGuardrailErrors: boolean = false
   ): Promise<GuardrailsOpenAI> {
     // Create and initialize the guardrails client
-    const guardrailsClient = new GuardrailsBaseClientImpl(options?.apiKey);
+    const guardrailsClient = new GuardrailsBaseClientImpl();
     await guardrailsClient.initializeClient(config, options || {}, OpenAI);
 
     // Store the raiseGuardrailErrors setting
     guardrailsClient.raiseGuardrailErrors = raiseGuardrailErrors;
 
     // Create the instance with the initialized client
-    return new GuardrailsOpenAI(guardrailsClient, options);
+    return new GuardrailsOpenAI(options, guardrailsClient);
+  }
+
+  /** Clone SDK options while retaining the initialized guardrail pipeline. */
+  public override withOptions(options: Partial<ClientOptions>): this {
+    const clone = super.withOptions(options);
+    clone.guardrailsClient = this.guardrailsClient.withOptions(options);
+    clone.overrideResources();
+    return clone;
   }
 
   /**
@@ -118,7 +126,7 @@ export class GuardrailsOpenAI extends OpenAI {
  * Azure OpenAI subclass with automatic guardrail integration.
  */
 export class GuardrailsAzureOpenAI extends AzureOpenAI {
-  private guardrailsClient: GuardrailsBaseClientImplAzure;
+  private guardrailsClient!: GuardrailsBaseClientImplAzure;
 
   // Retain Azure OpenAI's original types for drop-in compatibility
   public override chat!: InstanceType<typeof AzureOpenAI>['chat'];
@@ -131,17 +139,17 @@ export class GuardrailsAzureOpenAI extends AzureOpenAI {
   };
 
   private constructor(
-    guardrailsClient: GuardrailsBaseClientImplAzure,
-    azureArgs: ConstructorParameters<typeof AzureOpenAI>[0]
+    azureArgs: ConstructorParameters<typeof AzureOpenAI>[0],
+    guardrailsClient?: GuardrailsBaseClientImplAzure
   ) {
     // Initialize Azure OpenAI client first
     super(azureArgs);
 
-    // Store the initialized guardrails client
-    this.guardrailsClient = guardrailsClient;
-
-    // Override chat and responses after initialization
-    this.overrideResources();
+    // SDK withOptions constructs the clone before its initialized guards are attached.
+    if (guardrailsClient) {
+      this.guardrailsClient = guardrailsClient;
+      this.overrideResources();
+    }
   }
 
   /**
@@ -168,7 +176,20 @@ export class GuardrailsAzureOpenAI extends AzureOpenAI {
     guardrailsClient.raiseGuardrailErrors = raiseGuardrailErrors;
 
     // Create the instance with the initialized client
-    return new GuardrailsAzureOpenAI(guardrailsClient, azureOptions);
+    return new GuardrailsAzureOpenAI(azureOptions, guardrailsClient);
+  }
+
+  /** Clone SDK options while retaining Azure routing and initialized guardrails. */
+  public override withOptions(options: Partial<AzureClientOptions>): this {
+    const azureOptions = {
+      apiVersion: this.apiVersion,
+      deployment: this.deploymentName,
+      ...options,
+    };
+    const clone = super.withOptions(azureOptions);
+    clone.guardrailsClient = this.guardrailsClient.withOptions(azureOptions);
+    clone.overrideResources();
+    return clone;
   }
 
   /**
@@ -206,27 +227,26 @@ export class GuardrailsAzureOpenAI extends AzureOpenAI {
  * Concrete implementation of GuardrailsBaseClient.
  */
 class GuardrailsBaseClientImpl extends GuardrailsBaseClient {
-  constructor(private readonly apiKey: ClientOptions['apiKey']) {
-    super();
-  }
-
   /**
    * Create default context with guardrail_llm client.
    */
   protected createDefaultContext(): GuardrailLLMContext {
-    // Create a separate client instance for guardrails (not the same as main client)
-    const guardrailClient = new OpenAI({
-      // The SDK's public apiKey is unresolved for callback credentials.
-      apiKey: typeof this.apiKey === 'function' ? this.apiKey : this._resourceClient.apiKey,
-      baseURL: this._resourceClient.baseURL,
-      organization: this._resourceClient.organization,
-      timeout: this._resourceClient.timeout,
-      maxRetries: this._resourceClient.maxRetries,
-    });
+    // Let the SDK preserve provider, workload identity, and callback credentials.
+    const guardrailClient = this._resourceClient.withOptions({});
 
     return {
       guardrailLlm: guardrailClient,
     };
+  }
+
+  public withOptions(options: Partial<ClientOptions>): GuardrailsBaseClientImpl {
+    const clone = new GuardrailsBaseClientImpl();
+    clone._resourceClient = this._resourceClient.withOptions(options);
+    clone.pipeline = this.pipeline;
+    clone.guardrails = this.guardrails;
+    clone.raiseGuardrailErrors = this.raiseGuardrailErrors;
+    clone.context = clone.createDefaultContext();
+    return clone;
   }
 
   /**
@@ -254,6 +274,18 @@ class GuardrailsBaseClientImplAzure extends GuardrailsBaseClient {
     return {
       guardrailLlm: guardrailClient,
     };
+  }
+
+  public withOptions(options: Partial<AzureClientOptions>): GuardrailsBaseClientImplAzure {
+    const clone = new GuardrailsBaseClientImplAzure();
+    const resource = this._resourceClient.withOptions(options);
+    clone._resourceClient = resource;
+    clone.pipeline = this.pipeline;
+    clone.guardrails = this.guardrails;
+    clone.raiseGuardrailErrors = this.raiseGuardrailErrors;
+    // Native Azure clones need the API version and deployment passed explicitly.
+    clone.context = { guardrailLlm: resource.withOptions(options) };
+    return clone;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@
  * applying guardrails to text-based methods that could benefit from validation.
  */
 
-import { AzureOpenAI, OpenAI } from 'openai';
+import { AzureOpenAI, type ClientOptions, OpenAI } from 'openai';
 import { GuardrailsBaseClient, type PipelineConfig } from './base-client';
 import type { Chat as GuardrailsChat } from './resources/chat';
 import type { Responses as GuardrailsResponses } from './resources/responses';
@@ -71,7 +71,7 @@ export class GuardrailsOpenAI extends OpenAI {
     raiseGuardrailErrors: boolean = false
   ): Promise<GuardrailsOpenAI> {
     // Create and initialize the guardrails client
-    const guardrailsClient = new GuardrailsBaseClientImpl();
+    const guardrailsClient = new GuardrailsBaseClientImpl(options?.apiKey);
     await guardrailsClient.initializeClient(config, options || {}, OpenAI);
 
     // Store the raiseGuardrailErrors setting
@@ -206,13 +206,18 @@ export class GuardrailsAzureOpenAI extends AzureOpenAI {
  * Concrete implementation of GuardrailsBaseClient.
  */
 class GuardrailsBaseClientImpl extends GuardrailsBaseClient {
+  constructor(private readonly apiKey: ClientOptions['apiKey']) {
+    super();
+  }
+
   /**
    * Create default context with guardrail_llm client.
    */
   protected createDefaultContext(): GuardrailLLMContext {
     // Create a separate client instance for guardrails (not the same as main client)
     const guardrailClient = new OpenAI({
-      apiKey: this._resourceClient.apiKey,
+      // The SDK's public apiKey is unresolved for callback credentials.
+      apiKey: typeof this.apiKey === 'function' ? this.apiKey : this._resourceClient.apiKey,
       baseURL: this._resourceClient.baseURL,
       organization: this._resourceClient.organization,
       timeout: this._resourceClient.timeout,

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -60,7 +60,7 @@ export class GuardrailSpec<TContext = object, TIn = TextInput, TCfg = object> {
    * @returns JSON schema describing the config model fields.
    */
   schema(): Record<string, unknown> {
-    return this.configSchema._def as Record<string, unknown>;
+    return this.configSchema._def as unknown as Record<string, unknown>;
   }
 
   /**


### PR DESCRIPTION
## Summary

Upgrade Agents, OpenAI, and Zod as one compatible set: Agents 0.17.2, OpenAI 7.9.0, and Zod 4.5.4. The separate dependency bumps cannot install together against the old peer constraints.

- Adapt LLM prompt schema inspection to Zod 4, preserve array field types, and keep PII defaults independent across configurations.
- Resolve Agents types and Runner through the public SDK entry point. Keep generated preflight checks blocking before model dispatch; ordinary input-stage execution follows the Agents default.
- Preserve provider, workload-identity, and callback authentication through SDK-owned client cloning. Keep initialized guardrails and requested option overrides when calling `withOptions()` on OpenAI and Azure clients.
- Include a major changeset and migration guide covering Zod schemas, native fetch, inherited SDK APIs, structured-output behavior, and client cloning. Pipeline JSON and factory entry points remain unchanged.

Supersedes standalone proposals #108, #110, and #112, leaving those PRs open for maintainers. Unrelated changes already on main remain intact.

## Validation

- Compatible clean install and dependency tree, with no force or legacy-peer flags.
- `npm run build`, credential-free `npm run test:run` (804 tests), `npm run lint`, and `npm run docs:check` pass.
- Built-package integration tests cover Agents session history, blocking preflight acceptance/rejection, native-fetch OpenAI/Azure calls, Zod 4 structured outputs, rotating callbacks, Bedrock and workload-identity authentication without ambient credentials, and repeated client cloning with guardrails/options preserved.
- Consumer compilation covers public Zod 4 schemas, custom registration, Agents tools, and client request types, and rejects Zod 3 schemas.
- Packed nested-dependency installation verifies Runner identity and session history without relying on hoisted agents-core.
- Two consecutive clean adversarial-review rounds on the current complete diff, with two fresh independent reviewers each, including security review.
