### PR TITLE
ci: use Node 24 LTS for publish and docs

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -59,7 +59,7 @@ it is not a separate credential-approval gate. No release environment approval i
 required. Maintain branch protections, code-owner review, required checks, and the
 merge queue, and restrict access to any administrative bypasses.
 
-The workflow uses npm trusted publishing (OIDC) with Node 22 and npm 11. Keep the
+The workflow uses npm trusted publishing (OIDC) with Node 24 and its bundled npm. Keep the
 npm trusted publisher configured for `openai/openai-guardrails-js` and the workflow
 filename `publish.yml`. No npm token is needed. GitHub Actions must be allowed to
 create pull requests in the repository settings.
@@ -90,4 +90,4 @@ happen together after merging the version PR, preventing a second tag-triggered
 publish of the same version.
 
 The release workflow uses Changesets CLI 2.x with the compatible Changesets action
-1.x on Node 22.
+1.x on Node 24.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,12 +28,9 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@11
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run test -- --run


### PR DESCRIPTION
## Summary

Use Node 24 LTS for publishing and documentation builds. Publishing now uses the npm bundled with Node 24, removing the separate global npm upgrade. The Node 22/24/26 test matrix and package engine requirements stay unchanged.

## Validation

- Verified Node 24.21.0 bundles npm 11.19.0, meeting npm trusted publishing's minimum version.
- Clean install, TypeScript build, 722 tests, Biome lint, documentation build and link checks pass using that Node/npm bundle.
- actionlint and git diff --check pass.
- Two consecutive clean adversarial-review rounds, with two independent fresh-context reviewers per round, including publishing security review.

No changeset is needed for this CI/release-tooling-only change. Actual npm publication and main-ref provenance verification remain a next-release check.
