### PR TITLE
fix: enforce GPT-4.1 guardrail response schemas

### DIFF
--- a/.changeset/quiet-jailbreak-results.md
+++ b/.changeset/quiet-jailbreak-results.md
@@ -1,0 +1,15 @@
+---
+"@openai/guardrails": patch
+---
+
+Use Structured Outputs for standard LLM guardrail results on OpenAI's GPT-4.1,
+GPT-4.1 mini, and GPT-4.1 nano models, including their 2025-04-14 snapshots, to
+require the decision and confidence fields even for benign input. Reasoning is
+required when enabled. Other models, providers, and custom output schemas retain
+their existing JSON mode behavior.
+
+Prevent validation-error logging from invoking Node's exception object inspector
+so that guardrail execution failures retain their diagnostics and token usage.
+
+The minimum dependency versions are now OpenAI SDK 4.55.0 and Zod 3.23.8. Update
+dependency overrides or resolutions that pin older versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@openai/agents": "^0.1.3",
-        "openai": "^4.0.0",
-        "zod": "^3.22.0"
+        "openai": "^4.55.0",
+        "zod": "^3.23.8"
       },
       "bin": {
         "guardrails": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   "homepage": "https://openai.github.io/openai-guardrails-js/",
   "dependencies": {
     "@openai/agents": "^0.1.3",
-    "openai": "^4.0.0",
-    "zod": "^3.22.0"
+    "openai": "^4.55.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.11",

--- a/src/__tests__/unit/llm-response-format.test.ts
+++ b/src/__tests__/unit/llm-response-format.test.ts
@@ -1,0 +1,192 @@
+import { inspect } from 'node:util';
+import { AzureOpenAI, OpenAI } from 'openai';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { jailbreak } from '../../checks/jailbreak';
+import { LLMConfig, LLMOutput, runLLM } from '../../checks/llm-base';
+
+const usage = { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 };
+
+function mockCompletion(client: OpenAI, content: string | null) {
+  return vi.spyOn(client.chat.completions, 'create').mockResolvedValue({
+    id: 'test-completion',
+    object: 'chat.completion',
+    created: 0,
+    model: 'gpt-4.1-mini',
+    choices: [
+      {
+        index: 0,
+        finish_reason: 'stop',
+        logprobs: null,
+        message: {
+          role: 'assistant',
+          content,
+          refusal: null,
+        },
+      },
+    ],
+    usage,
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('Jailbreak response format', () => {
+  it.each([
+    'gpt-4.1',
+    'gpt-4.1-mini',
+    'gpt-4.1-nano',
+    'gpt-4.1-2025-04-14',
+    'gpt-4.1-mini-2025-04-14',
+    'gpt-4.1-nano-2025-04-14',
+  ])('requires the decision fields on %s for benign input', async (model) => {
+    const client = new OpenAI({ apiKey: 'test-key' });
+    const create = mockCompletion(client, JSON.stringify({ flagged: false, confidence: 0.1 }));
+
+    const result = await jailbreak({ guardrailLlm: client }, 'Hello!', LLMConfig.parse({ model }));
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(create.mock.calls[0][0]).toMatchObject({
+      model,
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: {
+              flagged: { type: 'boolean' },
+              confidence: { type: 'number', minimum: 0, maximum: 1 },
+            },
+            required: ['flagged', 'confidence'],
+            additionalProperties: false,
+          },
+        },
+      },
+    });
+    expect(result.executionFailed).not.toBe(true);
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info.token_usage).toEqual(usage);
+  });
+
+  it.each([false, true])('requires reasoning when enabled, flagged=%s', async (flagged) => {
+    const client = new OpenAI({ apiKey: 'test-key' });
+    const create = mockCompletion(
+      client,
+      JSON.stringify({ flagged, confidence: 0.9, reason: 'Analysis.' })
+    );
+    const result = await jailbreak(
+      { guardrailLlm: client },
+      'Example text',
+      LLMConfig.parse({
+        model: 'gpt-4.1-mini',
+        include_reasoning: true,
+      })
+    );
+
+    expect(create.mock.calls[0][0]).toMatchObject({
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          schema: {
+            properties: { reason: { type: 'string' } },
+            required: ['flagged', 'confidence', 'reason'],
+          },
+        },
+      },
+    });
+    expect(result.executionFailed).not.toBe(true);
+    expect(result.tripwireTriggered).toBe(flagged);
+    expect(result.info.reason).toBe('Analysis.');
+  });
+
+  it.each(['gpt-4', 'gpt-4o', 'gpt-4.1-mini-custom', 'ft:gpt-4.1-mini-2025-04-14:custom'])(
+    'retains JSON mode for other models: %s',
+    async (model) => {
+      const client = new OpenAI({ apiKey: 'test-key' });
+      const create = mockCompletion(client, '{"flagged":false,"confidence":0.1}');
+      await jailbreak({ guardrailLlm: client }, 'Hello!', LLMConfig.parse({ model }));
+      expect(create.mock.calls[0][0].response_format).toEqual({ type: 'json_object' });
+    }
+  );
+
+  it.each(['azure', 'custom'])('retains JSON mode for %s providers', async (provider) => {
+    const client =
+      provider === 'azure'
+        ? new AzureOpenAI({
+            apiKey: 'test-key',
+            endpoint: 'https://example.openai.azure.com',
+            apiVersion: '2024-10-21',
+          })
+        : new OpenAI({ apiKey: 'test-key', baseURL: 'http://localhost:11434/v1' });
+    const create = mockCompletion(client, '{"flagged":false,"confidence":0.1}');
+    await jailbreak({ guardrailLlm: client }, 'Hello!', LLMConfig.parse({ model: 'gpt-4.1-mini' }));
+    expect(create.mock.calls[0][0].response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('preserves custom output schema behavior', async () => {
+    const client = new OpenAI({ apiKey: 'test-key' });
+    const create = mockCompletion(client, '{"flagged":false,"confidence":0.1}');
+    const outputModel = LLMOutput.extend({ detail: z.string().optional() });
+    const [result] = await runLLM('Hello!', 'Check the input', client, 'gpt-4.1-mini', outputModel);
+    expect(create.mock.calls[0][0].response_format).toEqual({ type: 'json_object' });
+    expect(result).toEqual({ flagged: false, confidence: 0.1 });
+  });
+});
+
+describe('LLM failure logging', () => {
+  it.each([
+    ['{}', 'LLM response validation failed.'],
+    ['{"flagged":false,"confidence":"0.1"}', 'LLM response validation failed.'],
+    ['not JSON', 'LLM returned non-JSON or malformed JSON.'],
+    [null, 'LLM returned no content'],
+  ])('preserves failure diagnostics and usage for %s', async (content, message) => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const warningLog = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const client = new OpenAI({ apiKey: 'test-key' });
+    mockCompletion(client, content);
+
+    const result = await jailbreak(
+      { guardrailLlm: client },
+      'Hello!',
+      LLMConfig.parse({ model: 'gpt-4.1-mini' })
+    );
+
+    expect(result.executionFailed).toBe(true);
+    expect(result.tripwireTriggered).toBe(false);
+    expect(result.info.error_message).toBe(message);
+    expect(result.info.token_usage).toEqual(usage);
+    if (content === '{}') {
+      expect(result.info.zod_issues).toEqual([
+        expect.objectContaining({ path: ['flagged'], code: 'invalid_type' }),
+        expect.objectContaining({ path: ['confidence'], code: 'invalid_type' }),
+      ]);
+    }
+    for (const args of [...errorLog.mock.calls, ...warningLog.mock.calls]) {
+      expect(args.every((arg) => typeof arg === 'string')).toBe(true);
+    }
+  });
+
+  it('does not invoke an exception object inspector', async () => {
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      for (const arg of args) inspect(arg);
+    });
+    const failure = new Error('Provider unavailable');
+    const inspector = vi.fn(() => {
+      throw new Error('Inspector failed');
+    });
+    Object.defineProperty(failure, inspect.custom, { value: inspector });
+    const client = new OpenAI({ apiKey: 'test-key' });
+    vi.spyOn(client.chat.completions, 'create').mockRejectedValue(failure);
+
+    const result = await jailbreak(
+      { guardrailLlm: client },
+      'Hello!',
+      LLMConfig.parse({ model: 'gpt-4.1-mini' })
+    );
+
+    expect(result.executionFailed).toBe(true);
+    expect(result.info.error_message).toContain('Provider unavailable');
+    expect(inspector).not.toHaveBeenCalled();
+  });
+});

--- a/src/checks/llm-base.ts
+++ b/src/checks/llm-base.ts
@@ -8,6 +8,7 @@
  */
 
 import type { OpenAI } from 'openai';
+import { zodResponseFormat } from 'openai/helpers/zod';
 import { type ZodTypeAny, z } from 'zod';
 import { defaultSpecRegistry } from '../registry';
 import {
@@ -441,6 +442,15 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     // Only include safety_identifier for official OpenAI API (not Azure or local providers)
     if (supportsSafetyIdentifier(client)) {
       params.safety_identifier = SAFETY_IDENTIFIER;
+
+      // Limit schema enforcement to the GPT-4.1 family and our standard outputs.
+      // Other models/providers and custom Zod schemas retain JSON mode compatibility.
+      if (
+        /^gpt-4\.1(?:-mini|-nano)?(?:-2025-04-14)?$/.test(model) &&
+        (Object.is(outputModel, LLMOutput) || Object.is(outputModel, LLMReasoningOutput))
+      ) {
+        params.response_format = zodResponseFormat(outputModel, 'guardrail_result');
+      }
     }
 
     // @ts-expect-error - safety_identifier is not in the OpenAI types yet
@@ -465,7 +475,9 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     const cleanedResult = stripJsonCodeFence(result);
     return [outputModel.parse(JSON.parse(cleanedResult)), tokenUsage];
   } catch (error) {
-    logLLMError('error', 'LLM guardrail failed for prompt:', systemPrompt, error);
+    // Logging exception objects can itself fail in Node's object inspector.
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logLLMError('error', 'LLM guardrail failed for prompt:', systemPrompt, errorMessage);
 
     // Check if this is a content filter error - Azure OpenAI
     if (error && typeof error === 'string' && error.includes('content_filter')) {
@@ -486,7 +498,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     // Fail-open on JSON parsing errors (malformed or non-JSON responses)
     // Use tokenUsage here since API call succeeded but response parsing failed
     if (error instanceof SyntaxError || (error as Error)?.constructor?.name === 'SyntaxError') {
-      logLLMError('warn', 'LLM returned non-JSON or malformed JSON.', error);
+      logLLMError('warn', 'LLM returned non-JSON or malformed JSON.', errorMessage);
       return [
         LLMErrorOutput.parse({
           flagged: false,
@@ -502,7 +514,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     // Fail-open on schema validation errors (e.g., wrong types like confidence as string)
     // Use tokenUsage here since API call succeeded but schema validation failed
     if (error instanceof z.ZodError) {
-      logLLMError('warn', 'LLM response validation failed.', error);
+      logLLMError('warn', 'LLM response validation failed.', errorMessage);
       return [
         LLMErrorOutput.parse({
           flagged: false,


### PR DESCRIPTION
## Summary

Jailbreak checks using `gpt-4.1-mini` can return valid JSON without the required `flagged` and `confidence` fields. Use the OpenAI SDK's Zod helper to request strict Structured Outputs for standard guardrail schemas on GPT-4.1, mini, and nano aliases and their 2025-04-14 snapshots. Require `reason` when reasoning is enabled. Other models, providers, and custom output schemas retain JSON mode, and local validation remains active.

Log exception messages through the protected logging wrapper from #126 so Node's inspector or a throwing logger cannot interrupt validation-error handling. Preserve execution-failure diagnostics and token usage. Raise the minimum OpenAI SDK version to 4.55.0 and Zod to 3.23.8 for the helper, and include a patch changeset.

Fixes #59.

## Validation

- `npm run test:run`: 791 tests pass across 39 files.
- `npm run build` and `npm run lint`: pass.
- Two consecutive clean adversarial-review rounds, each with two independent fresh-context read-only reviewers; defensive security review found no blockers.
- Tests cover model/provider compatibility, both reasoning settings, missing or malformed response fields, preserved diagnostics and token usage, and an exception whose inspector throws.
- Live-model reproduction remains unverified. The minimum-version helper exists in SDK 4.55.0; an optional isolated install of minimum dependencies did not complete, so runtime checks used the locked SDK 4.104.0 and Zod 3.25.76.

