### PR TITLE
fix: preserve LLM error recovery when logging throws

### DIFF
--- a/.changeset/quiet-llm-error-logging.md
+++ b/.changeset/quiet-llm-error-logging.md
@@ -1,0 +1,5 @@
+---
+'@openai/guardrails': patch
+---
+
+Preserve LLM guardrail error results and available token usage when console logging throws, including when Node.js cannot inspect a validation error.

--- a/src/__tests__/unit/llm-base.test.ts
+++ b/src/__tests__/unit/llm-base.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OpenAI } from 'openai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildAnalysisPayload,
   buildFullPrompt,
@@ -8,6 +9,7 @@ import {
   LLMConfig,
   LLMOutput,
   LLMReasoningOutput,
+  runLLM,
 } from '../../checks/llm-base';
 import { defaultSpecRegistry } from '../../registry';
 import type { GuardrailLLMContext, GuardrailLLMContextWithHistory } from '../../types';
@@ -22,6 +24,91 @@ vi.mock('../../registry', () => ({
 describe('LLM Base', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('error recovery when logging throws', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const usage = { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 };
+    const noUsage = {
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      unavailable_reason: 'LLM call failed before usage could be recorded',
+    };
+
+    it.each([
+      {
+        name: 'malformed JSON',
+        content: 'NOT JSON',
+        rejection: undefined,
+        flagged: false,
+        message: 'LLM returned non-JSON or malformed JSON.',
+      },
+      {
+        name: 'schema validation',
+        content: '{"flagged":false,"confidence":"invalid"}',
+        rejection: undefined,
+        flagged: false,
+        message: 'LLM response validation failed.',
+      },
+      {
+        name: 'provider content filter',
+        content: undefined,
+        rejection: 'content_filter',
+        flagged: true,
+        message: 'content_filter',
+      },
+      {
+        name: 'API failure',
+        content: undefined,
+        rejection: new Error('Provider unavailable'),
+        flagged: false,
+        message: 'Error: Provider unavailable',
+      },
+    ])('preserves $name results', async ({ content, rejection, flagged, message }) => {
+      const create = vi.fn();
+      if (rejection !== undefined) {
+        create.mockRejectedValue(rejection);
+      } else {
+        create.mockResolvedValue({ choices: [{ message: { content } }], usage });
+      }
+      const client = { chat: { completions: { create } } } as unknown as OpenAI;
+      const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const warnLog = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const run = () => runLLM('test text', 'Test system prompt', client, 'gpt-4', LLMOutput);
+      const expected = await run();
+
+      expect(expected).toEqual([
+        {
+          flagged,
+          confidence: flagged ? 1 : 0,
+          info: expect.objectContaining({ error_message: message }),
+        },
+        rejection === undefined ? usage : noUsage,
+      ]);
+      if (content?.includes('invalid')) {
+        expect(expected[0].info.zod_issues).toEqual([
+          expect.objectContaining({ code: 'invalid_type', path: ['confidence'] }),
+        ]);
+      }
+      if (flagged) {
+        expect(expected[0].info.third_party_filter).toBe(true);
+      }
+
+      const failLogging = () => {
+        throw new Error('Logging failed');
+      };
+      errorLog.mockImplementation(failLogging);
+      await expect(run()).resolves.toEqual(expected);
+      errorLog.mockImplementation(() => undefined);
+      warnLog.mockImplementation(failLogging);
+      await expect(run()).resolves.toEqual(expected);
+      errorLog.mockImplementation(failLogging);
+      await expect(run()).resolves.toEqual(expected);
+    });
   });
 
   describe('buildFullPrompt', () => {

--- a/src/checks/llm-base.ts
+++ b/src/checks/llm-base.ts
@@ -361,6 +361,14 @@ function stripJsonCodeFence(text: string): string {
   return candidate;
 }
 
+function logLLMError(level: 'error' | 'warn', ...args: unknown[]): void {
+  try {
+    console[level](...args);
+  } catch {
+    // Error inspection or logging must not interrupt guardrail error recovery.
+  }
+}
+
 /**
  * Run an LLM analysis for a given prompt and user input.
  *
@@ -457,11 +465,11 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     const cleanedResult = stripJsonCodeFence(result);
     return [outputModel.parse(JSON.parse(cleanedResult)), tokenUsage];
   } catch (error) {
-    console.error('LLM guardrail failed for prompt:', systemPrompt, error);
+    logLLMError('error', 'LLM guardrail failed for prompt:', systemPrompt, error);
 
     // Check if this is a content filter error - Azure OpenAI
     if (error && typeof error === 'string' && error.includes('content_filter')) {
-      console.warn('Content filter triggered by provider:', error);
+      logLLMError('warn', 'Content filter triggered by provider:', error);
       return [
         LLMErrorOutput.parse({
           flagged: true,
@@ -478,7 +486,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     // Fail-open on JSON parsing errors (malformed or non-JSON responses)
     // Use tokenUsage here since API call succeeded but response parsing failed
     if (error instanceof SyntaxError || (error as Error)?.constructor?.name === 'SyntaxError') {
-      console.warn('LLM returned non-JSON or malformed JSON.', error);
+      logLLMError('warn', 'LLM returned non-JSON or malformed JSON.', error);
       return [
         LLMErrorOutput.parse({
           flagged: false,
@@ -494,7 +502,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     // Fail-open on schema validation errors (e.g., wrong types like confidence as string)
     // Use tokenUsage here since API call succeeded but schema validation failed
     if (error instanceof z.ZodError) {
-      console.warn('LLM response validation failed.', error);
+      logLLMError('warn', 'LLM response validation failed.', error);
       return [
         LLMErrorOutput.parse({
           flagged: false,


### PR DESCRIPTION
## Summary

When Node.js throws while inspecting an LLM error for console logging, `runLLM` exits before returning its intended error result. Make its four error and warning calls best-effort so logging failures preserve error classification, diagnostics, token usage, and existing failure/tripwire behavior.

Adds focused regression coverage for malformed JSON, schema validation, provider content filters, and API failures with either or both console methods throwing, plus a patch changeset.

Fixes #60.

## Validation

- `npm run test:run`: 726 tests passed across 36 files.
- `npm run lint` and `npm run build`: passed.
- Two consecutive independent adversarial-review rounds passed, including security review of failure behavior.
