### PR TITLE
ci: bind publishing to the main-only environment

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -55,13 +55,20 @@ are intentionally available on every main-branch release workflow run, including
 runs that prepare a version PR and manual reruns on `main`.
 
 The Changesets version PR controls the normal version/changelog release process;
-it is not a separate credential-approval gate. No release environment approval is
-required. Maintain branch protections, code-owner review, required checks, and the
+it is not a separate credential-approval gate. The `publish` environment allows
+only the exact `main` branch and has no required reviewers. SDK-team review of
+the release PR is the human approval gate. Maintain branch protections,
+code-owner review, required checks, and the
 merge queue, and restrict access to any administrative bypasses.
 
 The workflow uses npm trusted publishing (OIDC) with Node 24 and its bundled npm. Keep the
 npm trusted publisher configured for `openai/openai-guardrails-js` and the workflow
-filename `publish.yml`. No npm token is needed. GitHub Actions must be allowed to
+filename `publish.yml`, with the environment set to `publish`. When introducing
+this binding, merge the workflow environment change and wait for all publish
+runs using the old workflow to finish before restricting the npm publisher to
+that environment. For recovery afterward, start a new workflow run on current
+`main` rather than rerunning a pre-change workflow revision.
+No npm token is needed. GitHub Actions must be allowed to
 create pull requests in the repository settings.
 
 Changesets uses the repository's `GITHUB_TOKEN` for version PRs, Git tags, and

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
   publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: publish
     permissions:
       contents: write
       pull-requests: write

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,6 +36,12 @@ Enable **Allow GitHub Actions to create and approve pull requests** in
 permissions can remain read-only; only the release job requests the writes it
 needs. Retain normal human reviews, required checks, and the merge queue.
 
+Configure the GitHub `publish` environment to allow only the exact `main` branch,
+with no required reviewers. SDK-team review of the release PR is the human
+approval gate.
+
 Keep the npm trusted publisher configured for owner `openai`, repository
-`openai-guardrails-js`, and workflow `publish.yml`, with no environment requirement.
-No npm token, App private key, or release environment is needed.
+`openai-guardrails-js`, workflow `publish.yml`, and environment `publish`.
+Follow the [environment rollout and recovery instructions](.changeset/README.md#publishing-trust-boundary)
+before tightening an existing publisher binding. No npm token or App private key
+is needed.


### PR DESCRIPTION
## Summary
Bind the publishing job to the `publish` environment, restricted to the exact `main` branch with no required reviewers. SDK-team review of release PRs remains the human approval gate.

The GitHub environment is already configured and independently verified. The release guide documents the npm trusted-publisher environment binding and rollout order: merge this PR, wait for older publish runs to finish, then set npm's environment to `publish`. The npm change is still pending authenticated access.

## Validation
- `npm run lint` and `git diff --check` pass.
- YAML parsing and main/environment assertions pass.
- Security review and three adversarial-review rounds completed; the final two rounds were clean. Fixed a rollout instruction to drain pre-change runs before restricting npm.
- No changeset: release automation only; package contents and public APIs are unchanged.
