### PR TITLE
fix: make LOCATION matching linear

### DIFF
--- a/.changeset/quiet-locations-scan.md
+++ b/.changeset/quiet-locations-scan.md
@@ -1,0 +1,5 @@
+---
+"@openai/guardrails": patch
+---
+
+Make LOCATION PII matching run in linear time while preserving street-address detection and masking for plaintext and decoded content.

--- a/src/__tests__/unit/checks/pii.test.ts
+++ b/src/__tests__/unit/checks/pii.test.ts
@@ -345,6 +345,65 @@ describe('pii guardrail', () => {
     expect(result.info?.checked_text).toBe('Ship to <LOCATION> for delivery.');
   });
 
+  describe.each([false, true])('LOCATION matching with block=%s', (block) => {
+    it.each([
+      ['Ship to 12 Oak St.', 'Ship to <LOCATION>.'],
+      ['At 45 7th Avenue!', 'At <LOCATION>!'],
+      ['12 Oak St and 34 Pine Rd', '<LOCATION>'],
+      ['12 Oak St; 34 Pine Rd', '<LOCATION>; <LOCATION>'],
+      ['12 Oak, Small Town, TX.', '<LOCATION>.'],
+      ['12 Oak,   Small Town  , TX.', '<LOCATION>.'],
+      ['12 Oak, , TX.', '<LOCATION>.'],
+      ['12 Oak, Town, TX; 34 Pine, City, CA', '<LOCATION>; <LOCATION>'],
+      ['12 Oak, Town, TX 34 Pine, City, CA', '<LOCATION> <LOCATION>'],
+      ['_12 Oak St; 34 Pine Rd', '_12 Oak St; <LOCATION>'],
+      ['１２ Oak St', '<LOCATION>'],
+    ])('preserves replacement spans for %s', async (text, expected) => {
+      const result = await pii(
+        {},
+        text,
+        PIIConfig.parse({ entities: [PIIEntity.LOCATION], block })
+      );
+
+      expect(result.tripwireTriggered).toBe(block);
+      expect(result.info?.checked_text).toBe(expected);
+      expect(result.info?.pii_detected).toBe(true);
+    });
+
+    it.each([
+      '12 apples and 34 pears',
+      '1234567 Oak St',
+      '_12 Oak St',
+      '12 Oak Street_extra',
+      '12 Oak, Town, Texas',
+      '12 Oak, Town',
+      '12 Oak,, TX',
+      '12 Oak, 7 Town, TX',
+    ])('leaves non-address text intact: %s', async (text) => {
+      const result = await pii(
+        {},
+        text,
+        PIIConfig.parse({ entities: [PIIEntity.LOCATION], block })
+      );
+
+      expect(result.tripwireTriggered).toBe(false);
+      expect(result.info?.checked_text).toBe(text);
+      expect(result.info?.detected_entities).toEqual({});
+    });
+
+    it('applies LOCATION matching to decoded text', async () => {
+      const encoded = Buffer.from('782 Maple Ridge Ave').toString('base64');
+      const result = await pii(
+        {},
+        `Address: ${encoded}`,
+        PIIConfig.parse({ entities: [PIIEntity.LOCATION], block, detect_encoded_pii: true })
+      );
+
+      expect(result.tripwireTriggered).toBe(block);
+      expect(result.info?.checked_text).toBe('Address: <LOCATION_ENCODED>');
+    });
+  });
+
   describe('NRP and PERSON deprecation (Issue #47)', () => {
     beforeEach(() => {
       // Clear deprecation warnings before each test to ensure clean state

--- a/src/checks/pii.ts
+++ b/src/checks/pii.ts
@@ -332,7 +332,7 @@ const DEFAULT_PII_PATTERNS: Record<PIIEntity, PatternDefinition[]> = {
         /\b\d{1,6}\s[A-Za-z0-9\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Place|Pl|Court|Ct|Way|Highway|Hwy|Parkway|Pkwy|Circle|Cir|Trail|Trl|Terrace|Ter)\b/gi,
     },
     {
-      regex: /\b\d{1,6}\s[A-Za-z0-9\s]+,\s*[A-Za-z\s]+,\s*[A-Z]{2}\b/g,
+      regex: /\b\d{1,6}\s[A-Za-z0-9\s]+,[A-Za-z\s]+,\s*[A-Z]{2}\b/g,
     },
   ],
   [PIIEntity.PERSON]: [{ regex: /\b[A-Z][a-z]+ [A-Z][a-z]+\b/g }],
@@ -405,6 +405,46 @@ const DEFAULT_PII_PATTERNS: Record<PIIEntity, PatternDefinition[]> = {
 };
 
 /**
+ * Try LOCATION only at the first house-number prefix in each maximal address
+ * body run. Any later prefix shares the same possible endpoints, so retrying
+ * it cannot find a match the first prefix missed. A greedy street match ends
+ * at the last suffix in the run; a city/state match ends beyond the run.
+ *
+ * Sticky matching prevents the engine from retrying all later starts. Each
+ * run is scanned a constant number of times, including the adjacent city and
+ * state runs. Keep the city pattern's whitespace alternatives non-overlapping
+ * so each individual attempt is linear as well. No input is truncated.
+ */
+function* _locationMatches(text: string, pattern: RegExp): Generator<RegExpExecArray> {
+  const regex = new RegExp(pattern.source, pattern.flags.replace('g', 'y'));
+  let previousEnd = 0;
+
+  for (const run of text.matchAll(/[A-Za-z0-9\s]+/g)) {
+    const offset = Math.max(run.index, previousEnd);
+    const runEnd = run.index + run[0].length;
+    if (offset >= runEnd) {
+      continue;
+    }
+
+    const body = text.slice(offset, runEnd);
+    for (const prefix of body.matchAll(/\b\d{1,6}\s/g)) {
+      const start = offset + prefix.index;
+      // A slice boundary must not create a word boundary in the original text.
+      if (start > 0 && /\w/.test(text[start - 1])) {
+        continue;
+      }
+      regex.lastIndex = start;
+      const match = regex.exec(text);
+      if (match) {
+        previousEnd = regex.lastIndex;
+        yield match;
+      }
+      break;
+    }
+  }
+}
+
+/**
  * Run regex analysis and collect findings by entity type.
  *
  * @param text The text to analyze for PII
@@ -474,23 +514,18 @@ function _collectPlainDetections(
 
     for (const definition of definitions) {
       const regex = new RegExp(definition.regex.source, definition.regex.flags);
-      let match: RegExpExecArray | null;
+      const matches =
+        entity === PIIEntity.LOCATION ? _locationMatches(text, regex) : text.matchAll(regex);
 
-      while ((match = regex.exec(text)) !== null) {
+      for (const match of matches) {
         const groupIndex = definition.group ?? 0;
         const matchedValue = match[groupIndex];
         if (!matchedValue) {
-          if (regex.lastIndex === match.index) {
-            regex.lastIndex += 1;
-          }
           continue;
         }
 
         const extracted = matchedValue.trim();
         if (!extracted) {
-          if (regex.lastIndex === match.index) {
-            regex.lastIndex += 1;
-          }
           continue;
         }
 
@@ -500,9 +535,6 @@ function _collectPlainDetections(
         const spanKey = `${entity}:${start}:${end}`;
 
         if (seen.has(spanKey)) {
-          if (regex.lastIndex === match.index) {
-            regex.lastIndex += 1;
-          }
           continue;
         }
 
@@ -520,10 +552,6 @@ function _collectPlainDetections(
           replacement: `<${entity}>`,
           priority: 2,
         });
-
-        if (regex.lastIndex === match.index) {
-          regex.lastIndex += 1;
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Make LOCATION matching linear in the input length while preserving address detection and replacement spans. Match each address-character run from its first eligible house number, and simplify redundant city whitespace matching.

Preserves plaintext and decoded-content detection, masking, blocking, word boundaries, and greedy suffix selection. Includes small functional regression fixtures and a patch changeset.

## Validation

- `npm run build`
- `npm run test:run` — 831 tests passed
- `npm run lint`
- `npm run docs:check`
- `npm run changeset -- status`
- `git diff --check`
- Two consecutive clean adversarial-review rounds, each with two independent fresh-context reviewers
