### PR TITLE
fix: safely recover from malformed LLM errors

### DIFF
--- a/.changeset/safe-llm-error-recovery.md
+++ b/.changeset/safe-llm-error-recovery.md
@@ -1,0 +1,5 @@
+---
+'@openai/guardrails': patch
+---
+
+Prevent malformed provider errors from interrupting LLM guardrail error recovery. Preserve ordinary error messages and existing provider content-filter decisions when reporting failures.

--- a/src/__tests__/unit/llm-base.test.ts
+++ b/src/__tests__/unit/llm-base.test.ts
@@ -27,6 +27,94 @@ describe('LLM Base', () => {
     vi.clearAllMocks();
   });
 
+  describe('malformed thrown values', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    const inaccessible = () => {
+      throw new Error('Inaccessible property');
+    };
+
+    it.each([
+      { name: 'null prototype', make: () => Object.create(null), message: '{}' },
+      { name: 'undefined', make: () => undefined, message: 'undefined' },
+      { name: 'null', make: () => null, message: 'null' },
+      { name: 'symbol', make: () => Symbol('failure'), message: 'Symbol(failure)' },
+      { name: 'provider string', make: () => 'unavailable', message: 'unavailable' },
+      { name: 'ordinary Error', make: () => new Error('failure'), message: 'Error: failure' },
+      {
+        name: 'failed string and JSON conversion',
+        make: () => ({ toString: inaccessible, toJSON: inaccessible }),
+        message: 'Unknown LLM error',
+      },
+      {
+        name: 'undefined JSON conversion',
+        make: () => ({ toString: inaccessible, toJSON: () => undefined }),
+        message: 'Unknown LLM error',
+      },
+      {
+        name: 'circular null-prototype object',
+        make: () => {
+          const value = Object.create(null);
+          value.self = value;
+          return value;
+        },
+        message: 'Unknown LLM error',
+      },
+      {
+        name: 'inaccessible constructor',
+        make: () => Object.defineProperty({}, 'constructor', { get: inaccessible }),
+        message: '[object Object]',
+      },
+      {
+        name: 'inaccessible prototype',
+        make: () => new Proxy({}, { getPrototypeOf: inaccessible }),
+        message: '[object Object]',
+      },
+      {
+        name: 'inaccessible message',
+        make: () => Object.defineProperty(new Error(), 'message', { get: inaccessible }),
+        message: '{}',
+      },
+      {
+        name: 'inaccessible stack',
+        make: () => Object.defineProperty(new Error('failure'), 'stack', { get: inaccessible }),
+        message: 'Error: failure',
+      },
+      {
+        name: 'changing stack',
+        make: () => {
+          let reads = 0;
+          return Object.defineProperty(new Error('failure'), 'stack', {
+            get: () => (++reads === 1 ? 'stack' : inaccessible()),
+          });
+        },
+        message: 'Error: failure',
+      },
+      {
+        name: 'inaccessible Zod issues',
+        make: () =>
+          new Proxy(new z.ZodError([]), {
+            get: (target, key, receiver) =>
+              key === 'issues' ? inaccessible() : Reflect.get(target, key, receiver),
+          }),
+        message: '[]',
+      },
+    ])('recovers from $name', async ({ make, message }) => {
+      const create = vi.fn().mockRejectedValue(make());
+      const client = { chat: { completions: { create } } } as unknown as OpenAI;
+      const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const [result, usage] = await runLLM('text', 'prompt', client, 'gpt-4', LLMOutput);
+
+      expect(result).toEqual({
+        flagged: false,
+        confidence: 0,
+        info: { error_message: message },
+      });
+      expect(usage.unavailable_reason).toBe('LLM call failed before usage could be recorded');
+      expect(log).toHaveBeenCalledWith('LLM guardrail failed for prompt:', 'prompt', message);
+    });
+  });
+
   describe('error recovery when logging throws', () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/src/checks/llm-base.ts
+++ b/src/checks/llm-base.ts
@@ -362,6 +362,39 @@ function stripJsonCodeFence(text: string): string {
   return candidate;
 }
 
+/** Preserve ordinary error messages without letting thrown values break recovery. */
+function safeErrorMessage(error: unknown): string {
+  try {
+    return String(error);
+  } catch {
+    // Some objects, including null-prototype objects, cannot be coerced.
+  }
+  try {
+    const json = JSON.stringify(error);
+    if (typeof json === 'string') return json;
+  } catch {
+    // Circular objects and throwing accessors may also prevent serialization.
+  }
+  return 'Unknown LLM error';
+}
+
+function classifyLLMError(error: unknown): {
+  kind: 'syntax' | 'schema' | 'other';
+  issues?: unknown;
+} {
+  try {
+    if (error instanceof SyntaxError || (error as Error)?.constructor?.name === 'SyntaxError') {
+      return { kind: 'syntax' };
+    }
+    if (error instanceof z.ZodError) {
+      return { kind: 'schema', issues: error.issues ?? [] };
+    }
+  } catch {
+    // Exception prototypes and properties may be inaccessible; use generic recovery.
+  }
+  return { kind: 'other' };
+}
+
 function logLLMError(level: 'error' | 'warn', ...args: unknown[]): void {
   try {
     console[level](...args);
@@ -476,7 +509,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
     return [outputModel.parse(JSON.parse(cleanedResult)), tokenUsage];
   } catch (error) {
     // Logging exception objects can itself fail in Node's object inspector.
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorMessage = safeErrorMessage(error);
     logLLMError('error', 'LLM guardrail failed for prompt:', systemPrompt, errorMessage);
 
     // Check if this is a content filter error - Azure OpenAI
@@ -488,16 +521,18 @@ export async function runLLM<TOutput extends ZodTypeAny>(
           confidence: 1.0,
           info: {
             third_party_filter: true,
-            error_message: String(error),
+            error_message: errorMessage,
           },
         }),
         noUsage,
       ];
     }
 
+    const classification = classifyLLMError(error);
+
     // Fail-open on JSON parsing errors (malformed or non-JSON responses)
     // Use tokenUsage here since API call succeeded but response parsing failed
-    if (error instanceof SyntaxError || (error as Error)?.constructor?.name === 'SyntaxError') {
+    if (classification.kind === 'syntax') {
       logLLMError('warn', 'LLM returned non-JSON or malformed JSON.', errorMessage);
       return [
         LLMErrorOutput.parse({
@@ -513,7 +548,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
 
     // Fail-open on schema validation errors (e.g., wrong types like confidence as string)
     // Use tokenUsage here since API call succeeded but schema validation failed
-    if (error instanceof z.ZodError) {
+    if (classification.kind === 'schema') {
       logLLMError('warn', 'LLM response validation failed.', errorMessage);
       return [
         LLMErrorOutput.parse({
@@ -521,7 +556,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
           confidence: 0.0,
           info: {
             error_message: 'LLM response validation failed.',
-            zod_issues: error.issues ?? [],
+            zod_issues: classification.issues,
           },
         }),
         tokenUsage,
@@ -534,7 +569,7 @@ export async function runLLM<TOutput extends ZodTypeAny>(
         flagged: false,
         confidence: 0.0,
         info: {
-          error_message: String(error),
+          error_message: errorMessage,
         },
       }),
       noUsage,


### PR DESCRIPTION
## Summary

Malformed provider exceptions can still escape `runLLM` when string conversion or error classification throws, even though logging itself is already protected on `main`. Guard both operations and return the existing generic failure result when classification is inaccessible.

Preserve successful `String(error)` messages, provider content-filter flagging, and JSON/schema failure token usage. Add focused regression tests and a patch changeset. No public API changes.

Addresses the remaining cases discussed in #64 and #60, building on the logging protection already on `main`.

## Thanks and credit

A huge thank-you to **Pranav Jadhav (@LuciferDono)** for the original fix in [#64](https://github.com/openai/openai-guardrails-js/pull/64)! Pranav did the work of introducing centralized error formatting, applying it across the LLM error paths, and adding a null-prototype regression test. That contribution gave us a concrete starting point for investigating the remaining recovery edge cases and directly informed this follow-up. We really appreciate the time, care, and effort put into making Guardrails more reliable for everyone.

Thank you as well to **@jackyzhen** for reporting the failure in [#60](https://github.com/openai/openai-guardrails-js/issues/60), including the environment, stack trace, and affected logging paths. That detailed report helped make the problem actionable.

This PR builds on their work and the subsequent review discussion, adapting the fix to current `main` while preserving existing error messages and guardrail decisions. Thank you both for helping us get this right!

## Validation

- `npm run build`
- `npm run test:run` — 871 tests pass
- `npm run lint`
- Two consecutive independent adversarial-review rounds, with two fresh-context reviewers each, found no in-scope blockers.
- Security review confirmed existing fail-open and provider content-filter behavior is preserved.
