### PR TITLE
chore: keep guardrails releases pre-1.0

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -7,8 +7,14 @@ releases.
 ## Contributing a release note
 
 For a user-visible SDK change, run `npm run changeset`, choose the appropriate
-patch, minor, or major bump, and write a short description of the change. Commit
+patch or minor bump, and write a short description of the change. Commit
 the generated `.changeset/*.md` file with the code.
+
+Keep `@openai/guardrails` pre-1.0 until an explicit stable-release decision. While
+the package is on `0.x`, use minor bumps for features and breaking changes, and
+patch bumps for compatible fixes. Clearly describe breaking changes and required
+migration steps in the release note. A major changeset selects `1.0.0` and should
+only be used when the stable release is explicitly approved.
 
 Add an entry for changes that materially affect package users: new features,
 bug fixes, public APIs or types, deprecations, breaking changes, and meaningful
@@ -89,7 +95,7 @@ Changesets continues the same `v<version>` naming for this single-package repo.
 Historical release notes remain in GitHub Releases; the generated changelog starts
 with the first Changesets release. The initial changesets cover the unreleased
 RequestOptions feature, twelve runtime fixes, and the breaking move to Node.js
-`^22.13.0 || >=24.0.0` since `v0.2.1`. The major changeset proposes version `1.0.0`; CI, tests,
+`^22.13.0 || >=24.0.0` since `v0.2.1`. The pending minor changesets propose version `0.3.0`; CI, tests,
 chores, documentation, and TypeScript cleanup are excluded from release notes.
 
 Pushing a tag no longer triggers npm publishing. Publishing and tag creation now

--- a/.changeset/coordinated-sdk-zod-upgrade.md
+++ b/.changeset/coordinated-sdk-zod-upgrade.md
@@ -1,5 +1,5 @@
 ---
-"@openai/guardrails": major
+"@openai/guardrails": minor
 ---
 
 Upgrade to Agents SDK 0.17, OpenAI SDK 7, and Zod 4 together. Custom guardrail schemas must use Zod 4, and applications sharing OpenAI or Agents clients should upgrade those dependencies too. Exported schema definitions, validation errors, and inherited OpenAI APIs now follow their new upstream versions. See the SDK migration guide for native fetch, schema defaults, and inherited API changes.

--- a/.changeset/node-22-minimum.md
+++ b/.changeset/node-22-minimum.md
@@ -1,5 +1,5 @@
 ---
-"@openai/guardrails": major
+"@openai/guardrails": minor
 ---
 
 **Breaking change:** Require Node.js 22.13 or later in the 22.x series, or Node.js 24 or newer (`^22.13.0 || >=24.0.0`). Support for Node.js 18 and 20 is removed; Node.js 22.0–22.12 and 23 are also unsupported. Upgrade applications on unsupported versions before installing this release. ([#92](https://github.com/openai/openai-guardrails-js/pull/92), [#82](https://github.com/openai/openai-guardrails-js/pull/82))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,8 +18,10 @@ for contributor instructions, first-release notes, and recovery procedures.
 No manual tag push, release-please configuration, or GitHub App is required.
 Existing release tags and GitHub Releases remain unchanged. The package stays at
 `0.2.1` until the first Changesets version PR is merged; the pending notes propose
-`1.0.0` because supported Node.js versions are now `^22.13.0 || >=24.0.0`,
-including removal of Node.js 18 and 20 support.
+`0.3.0`. Keep the package pre-1.0 until an explicit stable-release decision,
+using minor bumps for features and breaking changes and patches for compatible
+fixes. This release requires Node.js `^22.13.0 || >=24.0.0`, including removal of
+Node.js 18 and 20 support.
 
 ## Publishing authority
 


### PR DESCRIPTION
## Summary

The pending major changesets make release PR #117 select 1.0.0. Keep the package pre-1.0 by changing the Node.js minimum and coordinated SDK/Zod upgrade entries to minor bumps, retaining their migration notes. Changesets now selects **0.3.0** from 0.2.1.

Document that pre-1.0 features and breaking changes use minor bumps, compatible fixes use patches, and 1.0 requires an explicit stable-release decision. Merge this correction before #117 so release automation regenerates its version and changelog from the corrected source entries.

## Validation

- Changesets status: one minor release, 0.2.1 → 0.3.0; no major releases.
- Build and lint passed; all 856 tests passed.
- Two consecutive clean adversarial-review rounds, with two independent fresh-context reviewers per round.
