### PR TITLE
chore: document current contributor architecture and tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,62 @@ appropriate patch, minor, or major bump.
 Do not request a changeset for internal-only changes listed above. Generated
 release PRs consume changesets into the changelog; review their versions and
 changelog rather than asking for another changeset.
+
+
+## Repository map and supported tools
+
+This repository publishes one package, `@openai/guardrails`, from `dist/`.
+Use the owning module when changing a behavior:
+
+| Area | Ownership |
+| --- | --- |
+| Public exports | `src/index.ts` and emitted declarations |
+| OpenAI and Azure clients | `src/client.ts`, shared pipeline in `src/base-client.ts` |
+| Chat Completions and Responses | `src/resources/`; preserve request parameters and options |
+| Configuration and registration | `src/runtime.ts`, `src/spec.ts`, `src/registry.ts` |
+| Built-in checks | `src/checks/` and shared schema/output helpers in `src/utils/` |
+| Streaming output | `src/streaming.ts` and resource-specific stream handling |
+| Agents integration | `src/agents.ts` and shared conversation normalization |
+| Evaluation | `src/evals/` and `src/cli.ts` |
+| Tests | `src/__tests__/unit/` and `src/__tests__/integration/` |
+| Documentation | `docs/`, `docs/.vitepress/`, and `scripts/docs.test.mjs` |
+
+Use [package.json](package.json) and the committed npm lockfile as the toolchain
+source of truth. The current stack uses TypeScript 7, Vitest 4, Biome, and
+VitePress. Node support is declared in `engines`; CI tests Node 22, 24, and 26.
+The [SDK migration guide](docs/sdk_migration.md) documents the OpenAI 7,
+Agents 0.17, and Zod 4 compatibility boundaries.
+
+## Local verification
+
+From the repository root, the full CI-equivalent sequence is:
+
+```sh
+npm ci
+npm run build
+npm run test:run
+npm run lint
+npm run docs:check
+```
+
+Run the commands one at a time and stop on failure. Build before the tests:
+some SDK compatibility tests load the built CommonJS package and declarations.
+`npm run lint` checks formatting and imports as well as lint rules with Biome;
+a separate Prettier or ESLint installation is unnecessary. `npm run docs:check`
+builds VitePress and checks generated documentation URLs using Node. Python,
+MkDocs, uv, and Make are not required for these checks.
+
+During implementation, use focused tests such as
+`npm run test:run -- src/__tests__/unit/client.test.ts`. Run the full sequence
+for runtime, dependencies, build, test, or packaging changes. For contributor
+instructions and skill metadata only, validate the changed guidance, references,
+and metadata and run `git diff --check`; unchanged runtime tests need not be
+repeated. For site content, navigation, or documentation tooling changes, run
+`npm run docs:check` after installing dependencies. A local docs check does not
+publish the site.
+
+Use the repository's current configuration when formatting changed supported
+files. Biome does not cover Markdown or YAML here; review those formats and
+links directly. Preserve existing checks, and report exactly which checks ran
+and any failures or unavailable coverage. Release-note requirements are defined
+above and in the [release guide](.changeset/README.md).


### PR DESCRIPTION
Adds a contributor map and verification guidance for the current repository: TypeScript 7, Biome, Vitest, VitePress, and the OpenAI/Agents/Zod migration. Preserves the existing scope, worktree, review, and Changesets policies.

Part 1 of 6 adapting the contributor workflows from #69. Credits Kazuhiro Sera’s original work; this series uses the existing repository review procedure and npm toolchain instead of importing the custom Python review/handoff framework.

## Stack

This PR targets `main`; review its incremental diff against that branch. Merge in order from the bottom of the stack.

1. #132 — `codex/contributor-guidance` (this PR)
2. #133 — `codex/verification-workflow`
3. #134 — `codex/implementation-strategy`
4. #135 — `codex/final-review-workflow`
5. #136 — `codex/implementation-kickoff`
6. #137 — `codex/pr-handoff-workflow`

## Validation

- Verified changed-file scope, relative links at every stack commit, skill metadata, whitespace, and coauthor attribution.
- Internal contributor workflows only; no package changeset is needed.
- Full documented sequence passed on Node 22.22.0: `npm ci`, build, 856 tests, Biome, and VitePress build plus 2 documentation checks.
- Two consecutive clean adversarial-review rounds, with two independent fresh-context reviewers per round, covering every slice and the full stack.
