### PR TITLE
chore: add final review and implementation kickoff workflows

### DIFF
--- a/.agents/skills/implementation-final-review/SKILL.md
+++ b/.agents/skills/implementation-final-review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: implementation-final-review
+description: Prepare independent review of a complete Guardrails change before pushing or updating a PR, using the repository adversarial-review procedure.
+---
+
+# Implementation Final Review
+
+Apply the adversarial-review procedure in [AGENTS.md](../../../AGENTS.md).
+Use the installed `$adversarial-review` skill when available; otherwise follow
+that inline procedure. This skill supplies a reusable brief, not another gate.
+It applies to repository workflow changes as well as runtime changes before a
+push or PR update.
+
+## Prepare the complete scope
+
+Record the exact selected linked worktree, current HEAD, intended target, and
+comparison base SHA. Resolve the merge base with that target; for an explicitly
+requested stack, the previous PR's branch is the target. Inspect both the full
+stack and each incremental PR when reviewing several stacked changes together.
+Reviewers must check that every intermediate PR stands alone and references
+only files or skills present at that point.
+
+Include all branch commits from the comparison base, staged and unstaged
+changes, and relevant untracked deliverables. Ordinary `git diff` omits
+untracked files; provide their paths and contents explicitly. Distinguish local
+working notes from shipped files. Include individual commit diffs so an endpoint
+diff cannot conceal unrelated changes. Freeze task content while reviewers run.
+
+Read [reviewer-brief.md](references/reviewer-brief.md) when preparing dispatch.
+Fill it with the original outcome and constraints; do not include previous
+reviewers' conclusions or the implementer's preferred answer.
+
+## Dispatch and converge
+
+For each round, spawn exactly two new independent, read-only subagents with
+`fork_turns="none"`, both in this same worktree. Spawn both before waiting.
+Give each a complete self-contained brief. Reviewer A checks correctness,
+compatibility, security boundaries, and evidence. Reviewer B checks ownership,
+architecture, maintainability, and unnecessary complexity. Both inspect the
+entire change. They must not edit, modify Git state, or spawn agents.
+
+Aggregate supported findings and classify them using AGENTS.md. Fix only
+in-scope blockers. Require two consecutive clean rounds on unchanged content,
+with a fresh pair in every round and no more than ten rounds. A substantive
+change resets the clean-round count. Do not substitute a self-review or reused
+agent when fresh reviewers are unavailable; stop before pushing and report the
+limitation. Do not create additional tasks or worktrees for reviewers.
+
+## Close the review
+
+Run applicable [verification](../code-change-verification/SKILL.md), including
+focused evidence for repairs. Review any touched security surface and check
+[Changesets requirements](../../../.changeset/README.md). Internal-only workflow
+changes need no package release note. Preserve commit hooks; if committing or
+later edits change reviewed content, repeat the invalidated checks and review.
+
+Report scope, reviewer rounds, resolved in-scope findings, separate follow-ups,
+and actual verification results. Record evidence in working notes outside the
+shipped diff; no review-state certificate or component-credit reuse is needed.
+A clean local review does not authorize a merge or replace current-head CI.

--- a/.agents/skills/implementation-final-review/agents/openai.yaml
+++ b/.agents/skills/implementation-final-review/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Implementation Final Review"
+  short_description: "Review complete changes with independent reviewers"

--- a/.agents/skills/implementation-final-review/references/reviewer-brief.md
+++ b/.agents/skills/implementation-final-review/references/reviewer-brief.md
@@ -1,0 +1,39 @@
+# Independent reviewer brief
+
+Fill in every field before dispatch. Give each reviewer the same scope and its
+own lens; do not share the other reviewer's analysis or previous conclusions.
+
+- **Worktree:** absolute path to the selected linked worktree.
+- **Expected HEAD:** full SHA; verify it read-only before reviewing.
+- **Target and comparison base:** target branch and resolved full merge-base SHA.
+- **Original outcome and acceptance criteria:** the user's required result.
+- **Affected paths and contracts:** implementation and relevant tests/docs.
+- **Non-goals:** explicit limits, including unrelated preexisting defects.
+- **Complete diff:** branch commits, staged/unstaged changes, and a list of
+  relevant untracked deliverables. Identify operational notes separately.
+- **Stack, if any:** ordered base/head SHAs, intended PR scope, and acceptance
+  criteria for each slice; inspect each incremental diff and the combined result.
+- **Lens:** A: correctness, edge cases, failure modes, compatibility, security,
+  and test evidence. B: architecture, ownership, maintainability, performance,
+  complexity, and ecosystem fit. Both lenses cover the complete diff.
+
+Read the repository AGENTS.md for review and scope rules. Use the supplied HEAD
+as the intended checkout; do not fetch, switch, create a worktree, or select a
+new baseline. Stop and report if HEAD differs. Do not edit files, modify Git
+state, create tasks/PRs/comments, or spawn agents.
+
+For each supported finding, return priority, file/line, concrete impact,
+evidence, the smallest remedy, and one classification:
+
+1. Introduced or worsened defect: in-scope blocker.
+2. Narrowly necessary correction: in-scope blocker.
+3. Preexisting unrelated issue: separate follow-up.
+4. Broader improvement: separate follow-up.
+5. Serious concern requiring user agreement before a larger change.
+
+Require a matching, accurate changeset only for material package-user impact;
+for generated release PRs assess the generated version and changelog instead.
+Include a scoped security assessment if the changed surface requires one.
+Do not block on unsupported concerns, wording preferences, or unrelated cleanup.
+If no meaningful in-scope blockers remain, say so explicitly and identify any
+limits to the review evidence. For a stack, report the result for each slice.

--- a/.agents/skills/implementation-kickoff/SKILL.md
+++ b/.agents/skills/implementation-kickoff/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: implementation-kickoff
+description: Start or resume a requested Guardrails implementation or PR takeover in the selected linked worktree with bounded scope and verification.
+---
+
+# Implementation Kickoff
+
+Start from the user's actual implementation request. An investigation or a plan
+alone is not permission to implement, push, or publish. Preserve authorization
+already given; this skill adds none. Apply [AGENTS.md](../../../AGENTS.md) and
+[implementation-strategy](../implementation-strategy/SKILL.md) where applicable.
+
+## Establish the checkout and scope
+
+Record the original outcome, acceptance criteria, affected paths, non-goals,
+and intended base. Reuse the current task's selected linked worktree. If running
+in a primary checkout, follow AGENTS.md and ask to start or hand off to a worktree.
+Do not automatically create another worktree or change unrelated checkouts.
+
+Refresh remote references and record the full intended starting SHA. For a new
+independent task use the refreshed default branch unless the user chose another
+base. For an explicitly requested stack, use the exact previous slice's tip.
+Verify the checkout equals that SHA before editing a new task. For a resumed
+task, preserve its existing changes and record HEAD plus the original comparison
+base instead of resetting it to main. Stop on an unexplained base mismatch.
+
+Inspect tracked and untracked state before edits. Keep task deliverables distinct
+from existing user work and operational plans/review notes. Use `codex/` branch
+names by default, preserving an explicitly selected branch or user preference.
+
+## Take over an existing PR
+
+Read current metadata, author commits, discussions, and the complete PR diff.
+Confirm the PR is still an appropriate source. Preserve its underlying outcome,
+but evaluate the proposal against the current architecture and toolchain.
+Import only the accepted scope; a takeover does not require copying the entire
+patch or preserving intermediate commits.
+
+Record the source PR and verified author/coauthor identities. Credit adapted
+work with valid `Co-authored-by` trailers, without inventing identities. If the
+identity needed for attribution cannot be verified, resolve it before committing.
+For a split takeover, describe each slice as part of the replacement effort;
+do not claim the first slice completes the whole source PR.
+
+## Implement and verify
+
+Keep changes within the agreed scope. Preserve user work and avoid automatic
+stashing, rebasing, or rewriting unrelated branches. Check integration with an
+advanced target before submission; if an update is needed, handle only this
+task's branch and rerun checks/review affected by any content change. Do not
+force a detached checkout, one-commit topology, or history rewrite to manufacture
+a clean handoff.
+
+Use [verification](../code-change-verification/SKILL.md) and
+[final review](../implementation-final-review/SKILL.md) before pushing or creating
+or updating a PR. Follow the [release guide](../../../.changeset/README.md):
+ordinary user-visible SDK changes need a changeset; internal workflow changes
+need none. Leave version and changelog generation to the release PR.
+
+## Handoff
+
+Inspect status, full diff statistics, and every task commit before staging or
+reporting. Stage only task-owned deliverables; keep local planning and review
+artifacts out of the PR. Preserve hooks and inspect the committed result.
+
+Report branch, base, commit, requested outcome, verification, review status, and
+remaining blockers. When authorized to submit, follow AGENTS.md for current-head
+CI monitoring, scoped fixes, root-channel review requests, and feedback replies.
+For a requested stack, create each PR against its predecessor and verify that
+relationship. Do not assume all workflows run on feature-branch PR targets:
+inspect triggers and use an authorized manual CI run on each head when needed.
+Never merge or close the source PR without authorization.

--- a/.agents/skills/implementation-kickoff/agents/openai.yaml
+++ b/.agents/skills/implementation-kickoff/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Implementation Kickoff"
+  short_description: "Start bounded implementation and PR takeover work"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,3 +166,4 @@ external actions on their own.
 
 - [code-change-verification](.agents/skills/code-change-verification/SKILL.md): Verify changes with the current npm toolchain.
 - [implementation-strategy](.agents/skills/implementation-strategy/SKILL.md): Choose scope around existing Guardrails boundaries.
+- [implementation-final-review](.agents/skills/implementation-final-review/SKILL.md): Review complete changes with independent reviewers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,3 +167,4 @@ external actions on their own.
 - [code-change-verification](.agents/skills/code-change-verification/SKILL.md): Verify changes with the current npm toolchain.
 - [implementation-strategy](.agents/skills/implementation-strategy/SKILL.md): Choose scope around existing Guardrails boundaries.
 - [implementation-final-review](.agents/skills/implementation-final-review/SKILL.md): Review complete changes with independent reviewers.
+- [implementation-kickoff](.agents/skills/implementation-kickoff/SKILL.md): Start bounded implementation and PR takeover work.


### PR DESCRIPTION
Adds the repository final-review skill, independent reviewer brief, and implementation kickoff/takeover guidance. Includes the kickoff work accepted in #136, which merged into this branch. The incremental diff against main contains only final review and kickoff; verification and strategy are owned by #133.

## Stack

#132 and #133 have landed in main. The remaining dependency order is #135 → #137. #134 and #136 were merged into their parent branches, so their accepted work travels with #133 and #135 respectively. Merge the remaining PRs through the native queue in order; higher entries target their predecessor until it lands.

These contributor workflows adapt #69 to the current npm/Biome/VitePress toolchain and existing review procedure. Original authored commits and Kaz’s coauthor credit are preserved. No runtime, public API, dependency, or release behavior changes; no package changeset is needed.

## Validation

- Verified the repaired stack preserves the previously reviewed workflow file contents, without duplicate inherited patches.
- Verified per-slice scope, relative links, skill metadata, and coauthor attribution.
- Build, 871 tests, Biome, VitePress and 2 documentation tests passed.
- Two consecutive clean independent review rounds covered the complete stack, every original commit, and all surviving PR slices.
