### PR TITLE
chore: add PR handoff and review-follow-up guidance

### DIFF
--- a/.agents/skills/implementation-kickoff/SKILL.md
+++ b/.agents/skills/implementation-kickoff/SKILL.md
@@ -59,6 +59,9 @@ need none. Leave version and changelog generation to the release PR.
 
 ## Handoff
 
+Use [pr-draft-summary](../pr-draft-summary/SKILL.md) for the final description
+and authorized submission/follow-up.
+
 Inspect status, full diff statistics, and every task commit before staging or
 reporting. Stage only task-owned deliverables; keep local planning and review
 artifacts out of the PR. Preserve hooks and inspect the committed result.

--- a/.agents/skills/pr-draft-summary/SKILL.md
+++ b/.agents/skills/pr-draft-summary/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pr-draft-summary
+description: Draft a Guardrails PR from its complete final diff and carry out authorized CI and review follow-up, including stacked PRs and takeovers.
+---
+
+# PR Draft Summary
+
+Describe the complete final change, including internal tooling and docs PRs.
+Read [AGENTS.md](../../../AGENTS.md) for review, release-note, and remote-action
+rules. Drafting alone does not authorize submission or messages; retain explicit
+user authorization already given for the task.
+
+## Establish the actual PR scope
+
+Inspect the current branch, target, merge base, all branch commits, staged and
+unstaged changes, and relevant untracked deliverables. Use the intended target,
+not a feature branch's tracking configuration. For an explicit stack, compare
+against the previous PR's branch and list the required predecessor. Check the
+combined stack separately for integration and scope drift.
+
+Keep a user-selected branch; suggest an unused `codex/<topic>` name when needed.
+Do not include unrelated local notes. If the diff is empty, report that fact
+rather than inventing a PR. Reconcile the summary with the final diff after fixes.
+
+## Draft the title and body
+
+Lead with the concrete problem or missing capability and resulting behavior.
+Use a concise imperative title. Include only details needed to review the change:
+
+- What changes and why; relevant compatibility or migration requirements.
+- Actual tests/checks run, results, and material coverage limitations.
+- Changeset impact when it helps clarify release behavior.
+- For takeovers, the source PR and verified attribution; for split takeovers,
+  identify the slice without claiming the entire original PR is complete.
+- For stacks, the predecessor and ordered stack position. Explain that the
+  incremental diff is against that predecessor.
+
+Use native GitHub references (`#123` or `owner/repo#123`). Add issue-closing syntax
+only when the final change fully resolves that issue and closure is intended.
+Keep local paths, reviewer transcripts, internal diagnostics, and app directives
+out of the external description. Do not claim a check or approval that did not run.
+
+## Submit and follow up when authorized
+
+Before any push or PR update, complete the repository's
+[final review](../implementation-final-review/SKILL.md) and applicable
+[verification](../code-change-verification/SKILL.md). Push only the intended
+branches and create PRs with explicit bases. Do not rewrite another author's
+branch, merge, or close a source PR merely because a replacement exists.
+
+Monitor CI on the current head of every submitted PR. The current CI workflow
+filters PR targets to main, so higher stack entries may have no automatic run.
+Inspect `.github/workflows/ci.yml`; when needed, dispatch its existing manual
+workflow on each stack branch and verify each run's head SHA matches the PR.
+Missing checks are not passing checks. Report an unavailable trigger or blocked
+run rather than weakening CI or modifying branch protection.
+
+Fix and re-push only failures introduced/worsened by the change or narrowly
+necessary to its outcome, repeating the required review/checks before updates.
+Retry evidenced transient failures; report unrelated failures separately.
+Stop repeated retries when there is no new evidence or progress.
+
+Once current-head CI passes, request review in root `#sdk-reviews` as required by
+AGENTS.md and authorized for the task. For a stack, one message can list all PRs
+in dependency order; do not post it as a thread reply. If messaging is unavailable,
+report the blocker and provide the prepared request without claiming it was sent.
+
+When addressing feedback, inspect the whole affected diff, push the reviewed
+fix, then reply to the particular review thread explaining the correction and
+resolve it. Do not resolve feedback that remains unaddressed. If an earlier
+stack branch changes, reconcile dependent branches within the authorized scope
+and revalidate affected PR heads before reporting the stack as green.

--- a/.agents/skills/pr-draft-summary/agents/openai.yaml
+++ b/.agents/skills/pr-draft-summary/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "PR Draft Summary"
+  short_description: "Draft PRs and follow current-head CI and reviews"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,3 +168,4 @@ external actions on their own.
 - [implementation-strategy](.agents/skills/implementation-strategy/SKILL.md): Choose scope around existing Guardrails boundaries.
 - [implementation-final-review](.agents/skills/implementation-final-review/SKILL.md): Review complete changes with independent reviewers.
 - [implementation-kickoff](.agents/skills/implementation-kickoff/SKILL.md): Start bounded implementation and PR takeover work.
+- [pr-draft-summary](.agents/skills/pr-draft-summary/SKILL.md): Draft PRs and follow current-head CI and reviews.


### PR DESCRIPTION
Adds PR drafting, current-head CI monitoring, and authorized review-follow-up guidance, and connects the kickoff skill to the handoff skill. The incremental diff against main contains only this handoff work.

## Stack

#132, #133, and #135 have landed in main. #134 and #136 were merged into their parent branches and their accepted work has also landed. This is the final slice of the stack, now based directly on main.

These contributor workflows adapt #69 to the current npm/Biome/VitePress toolchain and existing review procedure. Original authored commits and Kaz’s coauthor credit are preserved. No runtime, public API, dependency, or release behavior changes; no package changeset is needed.

## Validation

- Verified the repaired stack preserves the previously reviewed workflow file contents, without duplicate inherited patches.
- Verified per-slice scope, relative links, skill metadata, and coauthor attribution.
- Build, 871 tests, Biome, VitePress and 2 documentation tests passed.
- Two consecutive clean independent review rounds covered the complete stack, every original commit, and all surviving PR slices.
